### PR TITLE
Add synthesis helper for binary relations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -102,4 +102,10 @@ export class SimpleGraphQueryEvaluator {
   }
 }
 
-export { synthesizeSelector, AtomSelectionExample, SelectorSynthesisError } from './SelectorSynthesizer';
+export {
+  synthesizeSelector,
+  synthesizeBinaryRelation,
+  AtomSelectionExample,
+  BinaryRelationExample,
+  SelectorSynthesisError,
+} from './SelectorSynthesizer';


### PR DESCRIPTION
## Summary
- refactor selector synthesis to support reusable normalization logic
- add binary relation synthesis capability that targets relation-valued expressions
- cover binary synthesis with new Jest scenarios and helpers

## Testing
- Not run (environment missing Node/npm)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69330ae98f64832c9a11c1860d95368e)