### PR TITLE
Add Amalgam-style synthesis explanations

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,25 @@ The selector synthesizer infers a relational expression that returns exactly the
 
 Although the implementation is enumerative, it follows the same spirit as CEGIS and FOIL-style learners: each candidate expression is validated against every provided example, immediately pruning failures before expanding the search frontier. This tight feedback loop keeps the search space tractable in bounded instances while still allowing compositional operators (e.g., joins composed under closure) to satisfy more relational targets. Raising the `maxDepth` parameter broadens the hypothesis space when more complex solutions are needed, while lower depths keep synthesis fast for simple selectors.
 
+### Synthesis "why" explanations
+
+The `synthesizeSelectorWithWhy` and `synthesizeBinaryRelationWithWhy` helpers return a provenance tree alongside the synthesized expression. Each returned `examples[i].why` value mirrors the final expression: every node records the operator kind, the textual subexpression, and the evaluated result for that subexpression in the corresponding datum. Binary operators (union, intersection, difference, join) list two children, closures list one, and identifiers are leaves.
+
+For example, synthesizing a selector for `{a1, a2}` and `{b1}` produces:
+
+```ts
+const { expression, examples } = synthesizeSelectorWithWhy([
+  { atoms: new Set([a1, a2]), datum: datumA },
+  { atoms: new Set([b1]), datum: datumB },
+]);
+
+// expression === "Thing"
+// examples[0].why === {
+//   kind: "identifier",
+//   expression: "Thing",
+//   result: new Set(["a1", "a2"]),
+// }
+```
+
+Synthesizing a binary relation explanation yields the same structure, but `result` contains normalized tuple identifiers (e.g., `"n1\u0000n3"`) for each subexpression. For a two-hop reachability example, the root `why` node would have `kind: "join"` with two child nodes describing the `edge` relations on the left and right of the join.
+

--- a/src/SelectorSynthesizer.ts
+++ b/src/SelectorSynthesizer.ts
@@ -19,6 +19,12 @@ type ExpressionNode =
   | { kind: "join"; left: ExpressionNode; right: ExpressionNode }
   | { kind: "closure"; child: ExpressionNode };
 
+// A provenance tree that mirrors the synthesized expression and captures the
+// evaluated result for each subexpression. Every node records the operator
+// kind, the subexpression text, and the normalized result (or null if the
+// expression does not evaluate in the given datum). Children follow the shape
+// of the grammar: binary operators produce two children, closures produce one,
+// and identifiers are leaves.
 export type WhyNode = {
   kind: ExpressionNode["kind"];
   expression: string;

--- a/src/SelectorSynthesizer.ts
+++ b/src/SelectorSynthesizer.ts
@@ -19,6 +19,13 @@ type ExpressionNode =
   | { kind: "join"; left: ExpressionNode; right: ExpressionNode }
   | { kind: "closure"; child: ExpressionNode };
 
+export type WhyNode = {
+  kind: ExpressionNode["kind"];
+  expression: string;
+  result: Set<string> | null;
+  children?: WhyNode[];
+};
+
 export class SelectorSynthesisError extends Error {}
 
 function nodeToString(node: ExpressionNode): string {
@@ -169,11 +176,11 @@ function matchesTargets(
   return true;
 }
 
-function synthesizeExpression(
+function synthesizeExpressionNode(
   examples: SynthesisExample[],
   normalizer: (result: unknown) => Set<string> | null,
   maxDepth = 3,
-): string {
+): ExpressionNode {
   // Enumerative, CEGIS-style search: we BFS over the expression grammar (identifiers, set ops, joins, closure),
   // checking each candidate against *all* examples before allowing it to generate children. Early rejection of
   // incorrect hypotheses keeps the frontier small (FOIL-esque pruning), while depth-bounding curbs blowup.
@@ -214,7 +221,7 @@ function synthesizeExpression(
     visited.add(key);
 
     if (matchesTargets(current.node, examples, normalizer)) {
-      return key;
+      return current.node;
     }
 
     if (current.depth >= maxDepth) {
@@ -248,7 +255,8 @@ export function synthesizeSelector(examples: AtomSelectionExample[], maxDepth = 
     target: new Set(Array.from(example.atoms).map((atom) => atom.id)),
   }));
 
-  return synthesizeExpression(synthesisExamples, normalizeUnaryResult, maxDepth);
+  const node = synthesizeExpressionNode(synthesisExamples, normalizeUnaryResult, maxDepth);
+  return nodeToString(node);
 }
 
 export function synthesizeBinaryRelation(
@@ -262,6 +270,98 @@ export function synthesizeBinaryRelation(
     return { datum: example.datum, target: encodedPairs };
   });
 
-  return synthesizeExpression(synthesisExamples, normalizeBinaryResult, maxDepth);
+  const node = synthesizeExpressionNode(synthesisExamples, normalizeBinaryResult, maxDepth);
+  return nodeToString(node);
+}
+
+function buildWhyNode(
+  node: ExpressionNode,
+  datum: IDataInstance,
+  normalizer: (result: unknown) => Set<string> | null,
+): WhyNode {
+  const result = evaluateExpression(node, datum, normalizer);
+  const base: WhyNode = {
+    kind: node.kind,
+    expression: nodeToString(node),
+    result,
+  };
+
+  switch (node.kind) {
+    case "identifier":
+      return base;
+    case "closure":
+      return { ...base, children: [buildWhyNode(node.child, datum, normalizer)] };
+    case "join":
+    case "union":
+    case "intersection":
+    case "difference":
+      return {
+        ...base,
+        children: [
+          buildWhyNode(node.left, datum, normalizer),
+          buildWhyNode(node.right, datum, normalizer),
+        ],
+      };
+    default:
+      return base;
+  }
+}
+
+export type SynthesisWhyExample = {
+  datum: IDataInstance;
+  target: Set<string>;
+  result: Set<string> | null;
+  why: WhyNode;
+};
+
+export type SynthesisWhy = {
+  expression: string;
+  examples: SynthesisWhyExample[];
+};
+
+export function synthesizeSelectorWithWhy(
+  examples: AtomSelectionExample[],
+  maxDepth = 3,
+): SynthesisWhy {
+  const synthesisExamples: SynthesisExample[] = examples.map((example) => ({
+    datum: example.datum,
+    target: new Set(Array.from(example.atoms).map((atom) => atom.id)),
+  }));
+
+  const node = synthesizeExpressionNode(synthesisExamples, normalizeUnaryResult, maxDepth);
+  const expression = nodeToString(node);
+
+  const explanationExamples: SynthesisWhyExample[] = synthesisExamples.map((example) => ({
+    datum: example.datum,
+    target: example.target,
+    result: evaluateExpression(node, example.datum, normalizeUnaryResult),
+    why: buildWhyNode(node, example.datum, normalizeUnaryResult),
+  }));
+
+  return { expression, examples: explanationExamples };
+}
+
+export function synthesizeBinaryRelationWithWhy(
+  examples: BinaryRelationExample[],
+  maxDepth = 3,
+): SynthesisWhy {
+  const synthesisExamples: SynthesisExample[] = examples.map((example) => {
+    const encodedPairs = new Set(
+      Array.from(example.pairs).map(([left, right]) => `${left.id}\u0000${right.id}`),
+    );
+    return { datum: example.datum, target: encodedPairs };
+  });
+
+  const node = synthesizeExpressionNode(synthesisExamples, normalizeBinaryResult, maxDepth);
+  const expression = nodeToString(node);
+
+  const explanationExamples: SynthesisWhyExample[] = synthesisExamples.map((example) => ({
+    datum: example.datum,
+    target: example.target,
+    result: evaluateExpression(node, example.datum, normalizeBinaryResult),
+    why: buildWhyNode(node, example.datum, normalizeBinaryResult),
+  }));
+
+  return { expression, examples: explanationExamples };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,12 @@ export class SimpleGraphQueryEvaluator {
 export {
   synthesizeSelector,
   synthesizeBinaryRelation,
+  synthesizeBinaryRelationWithWhy,
+  synthesizeSelectorWithWhy,
   AtomSelectionExample,
   BinaryRelationExample,
   SelectorSynthesisError,
+  SynthesisWhy,
+  SynthesisWhyExample,
+  WhyNode,
 } from './SelectorSynthesizer';

--- a/test/synthesis-why.test.ts
+++ b/test/synthesis-why.test.ts
@@ -1,0 +1,165 @@
+import {
+  synthesizeBinaryRelationWithWhy,
+  synthesizeSelectorWithWhy,
+} from "../src";
+import { IDataInstance, IAtom, IType, IRelation } from "../src/types";
+
+class RelationlessInstance implements IDataInstance {
+  private _types: IType[];
+
+  constructor(typeId: string, atomIds: string[]) {
+    this._types = [
+      {
+        id: typeId,
+        types: [typeId],
+        atoms: atomIds.map((id) => ({ id, type: typeId, label: id })),
+        isBuiltin: false,
+      },
+    ];
+  }
+
+  getAtomType(id: string): IType {
+    const match = this._types.find((t) => t.atoms.some((a) => a.id === id));
+    if (!match) throw new Error(`Missing atom ${id}`);
+    return match;
+  }
+
+  getTypes(): readonly IType[] {
+    return this._types;
+  }
+
+  getAtoms(): readonly IAtom[] {
+    return this._types.flatMap((t) => t.atoms);
+  }
+
+  getRelations(): readonly IRelation[] {
+    return [];
+  }
+}
+
+class RelationInstance implements IDataInstance {
+  private _types: IType[];
+  private _relations: IRelation[];
+
+  constructor(nodeIds: string[], relationName: string, edges: Array<[string, string]>) {
+    const nodeType: IType = {
+      id: "Node",
+      types: ["Node"],
+      atoms: nodeIds.map((id) => ({ id, type: "Node", label: id })),
+      isBuiltin: false,
+    };
+
+    this._types = [nodeType];
+    this._relations = [
+      {
+        id: relationName,
+        name: relationName,
+        types: ["Node", "Node"],
+        tuples: edges.map(([from, to]) => ({ atoms: [from, to], types: ["Node", "Node"] })),
+      },
+    ];
+  }
+
+  getAtomType(id: string): IType {
+    const match = this._types.find((t) => t.atoms.some((a) => a.id === id));
+    if (!match) throw new Error(`Missing atom ${id}`);
+    return match;
+  }
+
+  getTypes(): readonly IType[] {
+    return this._types;
+  }
+
+  getAtoms(): readonly IAtom[] {
+    return this._types.flatMap((t) => t.atoms);
+  }
+
+  getRelations(): readonly IRelation[] {
+    return this._relations;
+  }
+}
+
+function toAtomSet(ids: string[], instance: IDataInstance): Set<IAtom> {
+  const atomMap = new Map(instance.getAtoms().map((atom) => [atom.id, atom] as const));
+  return new Set(ids.map((id) => {
+    const atom = atomMap.get(id);
+    if (!atom) throw new Error(`Missing atom ${id}`);
+    return atom;
+  }));
+}
+
+function toPairSet(pairs: Array<[string, string]>, instance: IDataInstance): Set<readonly [IAtom, IAtom]> {
+  const atomMap = new Map(instance.getAtoms().map((atom) => [atom.id, atom] as const));
+  return new Set(
+    pairs.map(([left, right]) => {
+      const leftAtom = atomMap.get(left);
+      const rightAtom = atomMap.get(right);
+      if (!leftAtom || !rightAtom) throw new Error(`Missing atoms ${left}, ${right}`);
+      return [leftAtom, rightAtom] as const;
+    }),
+  );
+}
+
+function expectSet(result: Set<string> | null, expected: string[]) {
+  expect(result).not.toBeNull();
+  expect(result).toEqual(new Set(expected));
+}
+
+describe("synthesis explanations", () => {
+  it("returns a why-tree for synthesized selectors", () => {
+    const datumA = new RelationlessInstance("Thing", ["a1", "a2"]);
+    const datumB = new RelationlessInstance("Thing", ["b1"]);
+
+    const synthesis = synthesizeSelectorWithWhy([
+      { atoms: toAtomSet(["a1", "a2"], datumA), datum: datumA },
+      { atoms: toAtomSet(["b1"], datumB), datum: datumB },
+    ]);
+
+    expect(synthesis.expression).toBe("Thing");
+    expect(synthesis.examples).toHaveLength(2);
+
+    for (const example of synthesis.examples) {
+      expectSet(example.result, Array.from(example.target));
+      expect(example.why.kind).toBe("identifier");
+      expect(example.why.expression).toBe("Thing");
+      expect(example.why.children).toBeUndefined();
+    }
+  });
+
+  it("captures operator structure for binary relation synthesis", () => {
+    const datumA = new RelationInstance(
+      ["n1", "n2", "n3", "n4"],
+      "edge",
+      [
+        ["n1", "n2"],
+        ["n2", "n3"],
+        ["n3", "n4"],
+      ],
+    );
+    const datumB = new RelationInstance(
+      ["x1", "x2", "x3"],
+      "edge",
+      [
+        ["x1", "x2"],
+        ["x2", "x3"],
+      ],
+    );
+
+    const synthesis = synthesizeBinaryRelationWithWhy([
+      { pairs: toPairSet([["n1", "n3"], ["n2", "n4"]], datumA), datum: datumA },
+      { pairs: toPairSet([["x1", "x3"]], datumB), datum: datumB },
+    ]);
+
+    expect(synthesis.expression).toBe("edge.edge");
+    expect(synthesis.examples).toHaveLength(2);
+
+    for (const example of synthesis.examples) {
+      expectSet(example.result, Array.from(example.target));
+      expect(example.why.kind).toBe("join");
+      expect(example.why.children).toHaveLength(2);
+      const [left, right] = example.why.children ?? [];
+      expect(left?.expression).toBe("edge");
+      expect(right?.expression).toBe("edge");
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add Amalgam-style `why` explanations for synthesized selectors and binary relations
- expose new `withWhy` synthesis helpers and supporting provenance node types
- add tests covering selector and binary relation explanation trees

## Testing
- not run (npm command unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69342f3bf6d8832c9c0afe39cbee5edd)