### PR TITLE
Add evaluator support for `ni`, `two`, `set` and `implies ... else`

### DIFF
--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -275,6 +275,48 @@ describe("sgq-evaluator ", () => {
     expect(result12).toEqual(true);
   });
 
+  it("can evaluate non-membership and multiplicity operators", () => {
+    const datum = new TTTDataInstance();
+    const evaluatorUtil = new SimpleGraphQueryEvaluator(datum);
+
+    const nonMemberExpr = "X0 ni Board";
+    const nonMemberResult = evaluatorUtil.evaluateExpression(nonMemberExpr);
+    expect(nonMemberResult).toBe(true);
+
+    const memberExpr = "Board0 ni Board";
+    const memberResult = evaluatorUtil.evaluateExpression(memberExpr);
+    expect(memberResult).toBe(false);
+
+    const twoExpr = "two (X0 + O0)";
+    const twoResult = evaluatorUtil.evaluateExpression(twoExpr);
+    expect(twoResult).toBe(true);
+
+    const twoFalseExpr = "two X";
+    const twoFalseResult = evaluatorUtil.evaluateExpression(twoFalseExpr);
+    expect(twoFalseResult).toBe(false);
+
+    const setExpr = "set (X0 + O0)";
+    const setResult = evaluatorUtil.evaluateExpression(setExpr);
+    expect(areEquivalentTupleArrays(setResult, [["X0"], ["O0"]])).toBe(true);
+
+    const quantifierTwoExpr = "two i: X + O | true";
+    const quantifierTwoResult = evaluatorUtil.evaluateExpression(quantifierTwoExpr);
+    expect(quantifierTwoResult).toBe(true);
+  });
+
+  it("can evaluate implies with else", () => {
+    const datum = new TTTDataInstance();
+    const evaluatorUtil = new SimpleGraphQueryEvaluator(datum);
+
+    const expr1 = "false implies false else true";
+    const result1 = evaluatorUtil.evaluateExpression(expr1);
+    expect(result1).toEqual(true);
+
+    const expr2 = "true implies false else true";
+    const result2 = evaluatorUtil.evaluateExpression(expr2);
+    expect(result2).toEqual(false);
+  });
+
 
   it("can evaluate a transitive closure", () => {
     const datum = new TTTDataInstance();


### PR DESCRIPTION
### Motivation
- Implement Forge-like semantics for set non-membership and multiplicity operators so expressions like `X0 ni Board` and `two ...` behave correctly.
- Support `set`/`two` multiplicity checks and quantifier `two` to enable correct truthy evaluation of multiplicity expressions.
- Add conditional `implies ... else ...` semantics to allow the `IMP` operator to express a conditional consequent.

### Description
- Implemented `implies ... else ...` handling in `visitExpr3` to evaluate the `IMP` operator with an optional `ELSE_TOK` branch and to short-circuit antecedents correctly (`src/ForgeExprEvaluator.ts`).
- Added combined handling for `in` and `ni` in `visitExpr6` so `ni` negates membership tests and membership works for tuple arrays and single values (`src/ForgeExprEvaluator.ts`).
- Implemented `SET_TOK` and `TWO_TOK` handling in `visitExpr7` and added `TWO_TOK` checks in quantified comprehensions so `set` returns the set result and `two` checks cardinality equals two (`src/ForgeExprEvaluator.ts`).
- Extended quantifier multiplicity logic to support `two` both in comprehension short-circuit checks and final quantifier evaluation (`src/ForgeExprEvaluator.ts`).
- Added unit tests exercising `ni`, `set`, `two` (both as operator and quantifier), and `implies ... else` behavior (`test/basic.test.ts`).

### Testing
- Ran the test suite with `npm test` and all test suites passed (`10` test suites, `83` tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b97f6ecc4832c82b38de0d30a4844)