### PR TITLE
Move missing-name policy out of the evaluator

### DIFF
--- a/src/errorListener.ts
+++ b/src/errorListener.ts
@@ -1,5 +1,18 @@
 import { ANTLRErrorListener, Recognizer, RecognitionException } from "antlr4ts";
 
+export class ParseError extends Error {
+  constructor(
+    message: string,
+    public line: number,
+    public charPositionInLine: number,
+    public offendingSymbol?: unknown,
+    public recognitionException?: RecognitionException,
+  ) {
+    super(message);
+    this.name = "ParseError";
+  }
+}
+
 export class ParseErrorListener implements ANTLRErrorListener<any> {
   syntaxError(
     recognizer: Recognizer<any, any>,
@@ -9,6 +22,12 @@ export class ParseErrorListener implements ANTLRErrorListener<any> {
     msg: string,
     e: RecognitionException | undefined
   ) {
-    throw new Error(`Parse error at ${line}:${charPositionInLine}: ${msg}`);
+    throw new ParseError(
+      `Parse error at ${line}:${charPositionInLine}: ${msg}`,
+      line,
+      charPositionInLine,
+      offendingSymbol,
+      e,
+    );
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { ForgeParser, ExprContext, PredDeclContext } from './forge-antlr/ForgePa
 import { ForgeLexer } from './forge-antlr/ForgeLexer';
 import { ForgeListenerImpl } from './forge-antlr/ForgeListenerImpl';
 import { ParseTreeWalker } from 'antlr4ts/tree/ParseTreeWalker';
-import { EvalResult, ForgeExprEvaluator, NameNotFoundError } from './ForgeExprEvaluator';
+import { EvalResult, ForgeExprEvaluator } from './ForgeExprEvaluator';
 import { IDataInstance, IAtom, IRelation, ITuple, IType } from './types';
 import { ParseErrorListener } from './errorListener';
 
@@ -39,15 +39,7 @@ export class SimpleGraphQueryEvaluator {
 
   getExpressionParseTree(forgeExpr: string) {
     const parser = createForgeParser(forgeExpr);
-    const tree = parser.parseExpr();
-    
-    // TODO: Is this wrong?
-    if (!tree || tree.childCount === 0) {
-      throw new Error(`Parse error in ${forgeExpr}`);
-    }
-
-    //////// This is empty on parse error? //TODO//////
-    return tree;
+    return parser.parseExpr();
   }
 
 
@@ -67,9 +59,12 @@ export class SimpleGraphQueryEvaluator {
       }
       catch (e) {
         // if we can't parse the expression, we return an error
-        return {
-          error: new Error(`Error parsing expression "${forgeExpr}"`)
-        };
+        // Preserve the original error instance so callers can do
+        // `result.error instanceof ParseError`.
+        if (e instanceof Error) {
+          return { error: e, stackTrace: e.stack };
+        }
+        return { error: new Error(`Error parsing expression "${forgeExpr}"`) };
       }
     }
 
@@ -82,18 +77,12 @@ export class SimpleGraphQueryEvaluator {
       // ensure we're visiting an ExprContext
       return result;
     } catch (error) {
-      if (error instanceof NameNotFoundError) {
-        // Return an empty EvalResult for undefined names
-        let emptyResult: EvalResult = [];
-        return emptyResult;
-      }
+      // Preserve the original error instance so callers (notably spytial-core)
+      // can do `result.error instanceof NameNotFoundError` and apply their own
+      // policy (silent empty vs. surface-as-error). This evaluator is a pure
+      // engine; policy lives one layer up.
       if (error instanceof Error) {
-        const stackTrace = error.stack;
-        const errorMessage = error.message;
-        return {
-          error: new Error(`Error evaluating expression "${forgeExpr}": ${errorMessage}`),
-          stackTrace: stackTrace
-        };
+        return { error, stackTrace: error.stack };
       }
       return {
         error: new Error(`Error evaluating expression "${forgeExpr}"`)
@@ -101,6 +90,9 @@ export class SimpleGraphQueryEvaluator {
     }
   }
 }
+
+export { NameNotFoundError } from './ForgeExprEvaluator';
+export { ParseError, ParseErrorListener } from './errorListener';
 
 export {
   synthesizeSelector,

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -1,0 +1,72 @@
+import {
+  SimpleGraphQueryEvaluator,
+  ErrorResult,
+  EvaluationResult,
+  NameNotFoundError,
+  ParseError,
+} from "../src";
+import { TTTDataInstance } from "./testdatainstances";
+
+function isErrorResult(result: EvaluationResult): result is ErrorResult {
+  return (
+    typeof result === "object" &&
+    result !== null &&
+    !Array.isArray(result) &&
+    (result as ErrorResult).error instanceof Error
+  );
+}
+
+describe("sgq-evaluator error types", () => {
+  it("re-exports NameNotFoundError and ParseError as values (not just types)", () => {
+    expect(typeof NameNotFoundError).toBe("function");
+    expect(typeof ParseError).toBe("function");
+    expect(new NameNotFoundError("x")).toBeInstanceOf(Error);
+    expect(new ParseError("x", 1, 2)).toBeInstanceOf(Error);
+  });
+
+  it("returns ErrorResult with a typed ParseError for a syntactically invalid expression", () => {
+    const datum = new TTTDataInstance();
+    const evaluator = new SimpleGraphQueryEvaluator(datum);
+
+    // Unmatched brace — guaranteed syntactic failure.
+    const result = evaluator.evaluateExpression("{x : Player |");
+
+    expect(isErrorResult(result)).toBe(true);
+    if (isErrorResult(result)) {
+      expect(result.error).toBeInstanceOf(ParseError);
+      const parseError = result.error as ParseError;
+      expect(parseError.line).toBeGreaterThanOrEqual(1);
+      expect(typeof parseError.charPositionInLine).toBe("number");
+    }
+  });
+
+  it("preserves the original Error instance in ErrorResult.error (no re-wrapping)", () => {
+    // An arity mismatch throws a plain Error inside the evaluator. Previously
+    // that was re-wrapped as `new Error("Error evaluating expression...")`,
+    // which lost the original instance. The policy move requires preserving
+    // the instance so spytial-core can do `instanceof` checks on typed errors.
+    const datum = new TTTDataInstance();
+    const evaluator = new SimpleGraphQueryEvaluator(datum);
+
+    const result = evaluator.evaluateExpression("*(Board6.board)"); // arity 3
+
+    expect(isErrorResult(result)).toBe(true);
+    if (isErrorResult(result)) {
+      expect(result.error).toBeInstanceOf(Error);
+      // The message should originate from the evaluator, not a generic wrapper.
+      expect(result.error.message).not.toMatch(/^Error evaluating expression/);
+    }
+  });
+
+  it("still treats alphanumeric unknown identifiers as label literals (regression)", () => {
+    // The label-like fallback at ForgeExprEvaluator.ts:2161 must remain.
+    // Only non-matching identifiers (none reachable via the grammar today)
+    // would raise NameNotFoundError.
+    const datum = new TTTDataInstance();
+    const evaluator = new SimpleGraphQueryEvaluator(datum);
+
+    const result = evaluator.evaluateExpression("NonExistentRelation");
+
+    expect(result).toBe("NonExistentRelation");
+  });
+});


### PR DESCRIPTION
## Summary

Addresses [#47](https://github.com/sidprasad/simple-graph-query/issues/47). This is the first step of a two-repo change that moves the "silent empty vs. throw on missing name" policy out of this evaluator and into spytial-core, where it can be shared across all downstream consumers.

- Stop swallowing `NameNotFoundError` inside `evaluateExpression`. It now flows through and is preserved in `ErrorResult.error` as the original instance, so consumers can `instanceof`-check.
- Introduce a typed `ParseError` class (with `line`, `charPositionInLine`, `offendingSymbol`, `recognitionException`) thrown from `ParseErrorListener`. Previously it was a generic `Error`, indistinguishable from evaluation errors without string matching.
- Preserve the original error instance for the parse-error branch too (was being re-wrapped as a generic `Error`, losing the typed instance).
- Delete the `childCount === 0` check in `getExpressionParseTree`. Unreachable: `ParseErrorListener` throws on syntax errors before `parseExpr()` returns. The TODO comment already flagged the doubt.
- Re-export `NameNotFoundError`, `ParseError`, and `ParseErrorListener`.

## Why here, not in spytial-core

The user's motivating case is a spytial-py binary tree with `left`/`right` selectors where an individual instance only has `left` children. We want missing-name to be permissive end-to-end, but that choice shouldn't be baked into the evaluator — different contexts (a REPL vs. a layout pass vs. a synthesis run) may want different behavior. This PR makes the evaluator pure; the policy will land in spytial-core's `SGraphQueryEvaluator` wrapper in a follow-up.

## Behavior change for direct consumers

If anything uses `SimpleGraphQueryEvaluator` directly without going through spytial-core, `NameNotFoundError` will now arrive as an `ErrorResult` instead of being silently converted to `[]`. Grep shows the only direct consumer in this ecosystem is spytial-core; the accompanying spytial-core PR restores the end-to-end behavior.

## Test plan
- [x] `npx jest` — all 114 tests pass, including new `test/errors.test.ts`
- [x] `npx tsc --noEmit` — clean
- [ ] Reviewer: confirm the label-literal fallback at `ForgeExprEvaluator.ts:2161` is still the correct semantic for alphanumeric unknown names (unchanged by this PR; existing test still passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)