### PR TITLE
Static analyzer for Forge expressions (data-free + optional schema)

### DIFF
--- a/src/ForgeExprStaticAnalyzer.ts
+++ b/src/ForgeExprStaticAnalyzer.ts
@@ -175,33 +175,10 @@ export class ForgeExprStaticAnalyzer
   implements ForgeVisitor<Abstract>
 {
   private readonly schema?: SchemaInfo;
-  // Stack of name-binding frames introduced by enclosing scopes (set
-  // comprehensions today; quantifiers/let when they get analyzed). A name
-  // appearing in any frame must not be looked up in the schema — its value
-  // is whatever the binder supplies, which we cannot reason about statically.
-  private readonly boundScopes: Array<Set<string>> = [];
 
   constructor(schema?: IForgeSchema) {
     super();
     if (schema) this.schema = new SchemaInfo(schema);
-  }
-
-  private isBound(name: string): boolean {
-    for (const frame of this.boundScopes) {
-      if (frame.has(name)) return true;
-    }
-    return false;
-  }
-
-  // Run `fn` with `names` pushed onto the scope stack. try/finally so a thrown
-  // visit doesn't leak frames into sibling analyses.
-  private withBoundScope<T>(names: Set<string>, fn: () => T): T {
-    this.boundScopes.push(names);
-    try {
-      return fn();
-    } finally {
-      this.boundScopes.pop();
-    }
   }
 
   // Walk a nameList (`a, b, c`) and accumulate identifiers into `out`.
@@ -216,6 +193,24 @@ export class ForgeExprStaticAnalyzer
     this.collectNamesFromList(ctx.quantDecl().nameList(), out);
     const tail = ctx.quantDeclList();
     if (tail) this.collectBoundNames(tail, out);
+  }
+
+  // Policy: when a schema is provided, type and relation names are reserved —
+  // they may only refer to the schema entity. Returns an ill-typed Abstract if
+  // any candidate name collides; undefined otherwise.
+  private illTypedIfBindsReservedName(names: Iterable<string>): Abstract | undefined {
+    if (!this.schema) return undefined;
+    for (const name of names) {
+      if (this.schema.getType(name) || this.schema.getRelation(name)) {
+        return {
+          kind: "ill-typed",
+          reason:
+            `cannot bind variable named '${name}': it is a reserved schema ` +
+            `${this.schema.getType(name) ? "type" : "relation"} name`,
+        };
+      }
+    }
+    return undefined;
   }
 
   // Public entry: convert internal lattice value to a verdict + reason.
@@ -273,12 +268,24 @@ export class ForgeExprStaticAnalyzer
     const blockOrBar = ctx.blockOrBar();
     if (!blockOrBar) return UNKNOWN;
 
+    // Reserved-name check at the binder: under a schema, type/relation names
+    // cannot be reused as quantified variables.
+    const declListTop = ctx.quantDeclList();
+    if (declListTop) {
+      const boundHere = new Set<string>();
+      this.collectBoundNames(declListTop, boundHere);
+      const reservedError = this.illTypedIfBindsReservedName(boundHere);
+      if (reservedError) return reservedError;
+    }
+
     // Determine if any quantified domain is statically empty.
     let domainEmpty = false;
     let declList = ctx.quantDeclList();
     while (declList) {
       const setExpr = declList.quantDecl().expr();
-      if (this.visit(setExpr).kind === "empty") {
+      const v = this.visit(setExpr);
+      if (v.kind === "ill-typed") return v;
+      if (v.kind === "empty") {
         domainEmpty = true;
         break;
       }
@@ -844,9 +851,9 @@ export class ForgeExprStaticAnalyzer
     }
     if (ctx.LEFT_CURLY_TOK()) {
       // Set comprehension `{x : S | body}` is empty if any quantified set is
-      // empty, or if the body is statically false. Domain expressions evaluate
-      // in the OUTER scope (the variable isn't bound yet for its own domain),
-      // so we only need to push a scope before visiting the body.
+      // empty, or if the body is statically false. We also enforce the
+      // reserved-name policy here: under a schema, type/relation names cannot
+      // be reused as binder variables.
       const declList = ctx.quantDeclList();
       const boundHere = new Set<string>();
       if (declList) {
@@ -856,17 +863,19 @@ export class ForgeExprStaticAnalyzer
           const setExpr = cur.quantDecl().expr();
           const v = this.visit(setExpr);
           if (v.kind === "empty") return { kind: "empty" };
+          if (v.kind === "ill-typed") return v;
           this.collectNamesFromList(cur.quantDecl().nameList(), boundHere);
           const next = cur.quantDeclList();
           if (!next) break;
           cur = next;
         }
       }
+      const reservedError = this.illTypedIfBindsReservedName(boundHere);
+      if (reservedError) return reservedError;
       const blockOrBar = ctx.blockOrBar();
       if (blockOrBar && blockOrBar.BAR_TOK() && blockOrBar.expr()) {
-        const body = this.withBoundScope(boundHere, () =>
-          this.visit(blockOrBar.expr()!),
-        );
+        const body = this.visit(blockOrBar.expr()!);
+        if (body.kind === "ill-typed") return body;
         if (body.kind === "bool" && !body.value) return { kind: "empty" };
       }
       return UNKNOWN;
@@ -886,9 +895,6 @@ export class ForgeExprStaticAnalyzer
     const id = getIdentifierName(ctx);
     if (id === "true") return { kind: "bool", value: true };
     if (id === "false") return { kind: "bool", value: false };
-    // If this name is shadowed by an enclosing binder, we cannot reason about
-    // it from the schema — the bound value can be anything.
-    if (this.isBound(id)) return UNKNOWN;
     if (this.schema) {
       const t = this.schema.getType(id);
       if (t) return { kind: "typed", arity: 1, columnTypes: [t.id] };

--- a/src/ForgeExprStaticAnalyzer.ts
+++ b/src/ForgeExprStaticAnalyzer.ts
@@ -1,0 +1,855 @@
+import { AbstractParseTreeVisitor } from "antlr4ts/tree/AbstractParseTreeVisitor";
+import { ParseTree } from "antlr4ts/tree/ParseTree";
+import { ForgeVisitor } from "./forge-antlr/ForgeVisitor";
+import {
+  Expr1Context,
+  Expr1_5Context,
+  Expr2Context,
+  Expr3Context,
+  Expr4Context,
+  Expr5Context,
+  Expr6Context,
+  Expr7Context,
+  Expr8Context,
+  Expr9Context,
+  Expr11Context,
+  Expr12Context,
+  Expr14Context,
+  Expr15Context,
+  Expr17Context,
+  Expr18Context,
+  ExprContext,
+  NameContext,
+  BlockContext,
+  QuantContext,
+} from "./forge-antlr/ForgeParser";
+import { getIdentifierName } from "./forge-antlr/utils";
+import { IForgeSchema, IRelation, IType } from "./types";
+
+// Internal lattice element used during recursion.
+// "bool"/"num" carry the constant they fold to; "empty" means a set/relation
+// is provably empty; "typed" means a relation with a known arity and (when
+// derivable) column types; "ill-typed" means the expression is statically
+// malformed (arity mismatch, etc.); "unknown" is the conservative top.
+type Abstract =
+  | { kind: "bool"; value: boolean }
+  | { kind: "num"; value: number }
+  | { kind: "empty" }
+  | { kind: "typed"; arity: number; columnTypes?: readonly string[] }
+  | { kind: "ill-typed"; reason: string }
+  | { kind: "unknown" };
+
+const UNKNOWN: Abstract = { kind: "unknown" };
+
+export type StaticAnalysis =
+  | { status: "unsat"; reason: string }       // boolean expr provably false
+  | { status: "tautology"; reason: string }   // boolean expr provably true
+  | { status: "empty"; reason: string }       // set/relation expr provably empty
+  | { status: "ill-typed"; reason: string }   // statically malformed (e.g. arity mismatch)
+  | { status: "unknown" };
+
+// Helper that wraps the schema with O(1) lookups and lattice queries.
+class SchemaInfo {
+  private readonly typesById: Map<string, IType>;
+  private readonly relationsByName: Map<string, IRelation>;
+
+  constructor(schema: IForgeSchema) {
+    this.typesById = new Map(schema.getTypes().map((t) => [t.id, t]));
+    this.relationsByName = new Map(schema.getRelations().map((r) => [r.name, r]));
+  }
+
+  getType(id: string): IType | undefined { return this.typesById.get(id); }
+  getRelation(name: string): IRelation | undefined { return this.relationsByName.get(name); }
+
+  // A ⊆ B when B is in A's lineage. `IType.types` is the lineage in ascending
+  // order, conventionally starting with the type itself.
+  isSubtypeOf(a: string, b: string): boolean {
+    if (a === b) return true;
+    const t = this.typesById.get(a);
+    if (!t) return false;
+    return t.types.includes(b);
+  }
+
+  // Closed-world disjointness: A and B are disjoint iff no type in the
+  // schema has both A and B in its lineage (i.e., no common subtype exists).
+  // Sound only when the caller treats the supplied schema as complete.
+  areDisjoint(a: string, b: string): boolean {
+    if (a === b) return false;
+    for (const t of this.typesById.values()) {
+      if (t.types.includes(a) && t.types.includes(b)) return false;
+    }
+    return true;
+  }
+}
+
+// ANTLR's .text concatenates child tokens without whitespace, which gives us
+// a usable canonical form for "syntactically the same subexpression".
+function sameSubtree(a: ParseTree | undefined, b: ParseTree | undefined): boolean {
+  if (!a || !b) return false;
+  return a.text === b.text;
+}
+
+// True iff `ctx` is structurally a difference whose subtrahend (anywhere in a
+// left-associated minus chain) matches `targetText`. Strips parens and
+// pass-through wrappers. Examples that match for target="X":
+//   X - X       (Y - X)       (Y - Z - X)       ((Y - X) - Z)
+function subtractsTarget(ctx: ParseTree | undefined, targetText: string): boolean {
+  if (!ctx) return false;
+  let cur: ParseTree = ctx;
+  while (cur.childCount === 1) cur = cur.getChild(0);
+  if (cur instanceof Expr18Context && cur.LEFT_PAREN_TOK()) {
+    return subtractsTarget(cur.expr()!, targetText);
+  }
+  if (cur instanceof Expr8Context && cur.MINUS_TOK()) {
+    if (cur.expr10()!.text === targetText) return true;
+    // Chain: `A - B - target` parses left-assoc as `((A - B) - target)`;
+    // recurse on the left to catch deeper occurrences.
+    return subtractsTarget(cur.expr8()!, targetText);
+  }
+  return false;
+}
+
+// True iff `ctx` is structurally an intersection involving `targetText`
+// (so `ctx ⊆ target`). Walks through parens, pass-throughs, and chains of `&`.
+function intersectionInvolves(ctx: ParseTree | undefined, targetText: string): boolean {
+  if (!ctx) return false;
+  let cur: ParseTree = ctx;
+  while (cur.childCount === 1) cur = cur.getChild(0);
+  if (cur instanceof Expr18Context && cur.LEFT_PAREN_TOK()) {
+    return intersectionInvolves(cur.expr()!, targetText);
+  }
+  if (cur instanceof Expr11Context && cur.AMP_TOK()) {
+    if (cur.expr11()!.text === targetText) return true;
+    if (cur.expr12()!.text === targetText) return true;
+    return (
+      intersectionInvolves(cur.expr11()!, targetText) ||
+      intersectionInvolves(cur.expr12()!, targetText)
+    );
+  }
+  return false;
+}
+
+// True iff `ctx` is structurally a union containing `targetText`
+// (so `target ⊆ ctx`). Walks through parens, pass-throughs, and chains of `+`.
+function unionContains(ctx: ParseTree | undefined, targetText: string): boolean {
+  if (!ctx) return false;
+  let cur: ParseTree = ctx;
+  while (cur.childCount === 1) cur = cur.getChild(0);
+  if (cur instanceof Expr18Context && cur.LEFT_PAREN_TOK()) {
+    return unionContains(cur.expr()!, targetText);
+  }
+  if (cur instanceof Expr8Context && cur.PLUS_TOK()) {
+    if (cur.expr8()!.text === targetText) return true;
+    if (cur.expr10()!.text === targetText) return true;
+    return (
+      unionContains(cur.expr8()!, targetText) ||
+      unionContains(cur.expr10()!, targetText)
+    );
+  }
+  return false;
+}
+
+// Strip wrapping parens / pass-through expr layers to reveal an inner NEG_TOK
+// at the expr5 level. Returns the operand-text if `ctx` is structurally `not E`,
+// else undefined.
+function negationOperandText(ctx: ParseTree | undefined): string | undefined {
+  if (!ctx) return undefined;
+  let cur: ParseTree = ctx;
+  while (cur.childCount === 1) {
+    cur = cur.getChild(0);
+  }
+  if (cur instanceof Expr5Context && cur.NEG_TOK()) {
+    const inner = cur.expr5();
+    return inner ? inner.text : undefined;
+  }
+  if (cur instanceof Expr18Context && cur.LEFT_PAREN_TOK()) {
+    return negationOperandText(cur.expr()!);
+  }
+  return undefined;
+}
+
+export class ForgeExprStaticAnalyzer
+  extends AbstractParseTreeVisitor<Abstract>
+  implements ForgeVisitor<Abstract>
+{
+  private readonly schema?: SchemaInfo;
+
+  constructor(schema?: IForgeSchema) {
+    super();
+    if (schema) this.schema = new SchemaInfo(schema);
+  }
+
+  // Public entry: convert internal lattice value to a verdict + reason.
+  analyze(ctx: ParseTree): StaticAnalysis {
+    const v = this.visit(ctx);
+    if (v.kind === "bool") {
+      return v.value
+        ? { status: "tautology", reason: "expression folds to literal true" }
+        : { status: "unsat", reason: "expression folds to literal false" };
+    }
+    if (v.kind === "empty") {
+      return { status: "empty", reason: "expression is provably the empty set" };
+    }
+    if (v.kind === "ill-typed") {
+      return { status: "ill-typed", reason: v.reason };
+    }
+    return { status: "unknown" };
+  }
+
+  // Arity of an Abstract when known; -1 means "not determinable".
+  private static arityOf(v: Abstract): number {
+    if (v.kind === "typed") return v.arity;
+    if (v.kind === "bool" || v.kind === "num") return 1; // singleton sets
+    if (v.kind === "empty") return -1; // empty has no committed arity
+    return -1;
+  }
+
+  protected defaultResult(): Abstract {
+    return UNKNOWN;
+  }
+
+  // Prefer the more specific child result when aggregating across siblings.
+  // For pass-through expr layers there's exactly one meaningful child; for
+  // wrapper nodes like `( expr )` the terminals contribute UNKNOWN and the
+  // real value comes from the single non-terminal child. Ill-typed always
+  // wins — if any subtree is statically malformed, the parent is too.
+  protected aggregateResult(aggregate: Abstract, nextResult: Abstract): Abstract {
+    if (aggregate.kind === "ill-typed") return aggregate;
+    if (nextResult.kind === "ill-typed") return nextResult;
+    if (aggregate.kind === "unknown") return nextResult;
+    return aggregate;
+  }
+
+  // Let/bind introduce data-dependent bindings; we don't fold through them.
+  // Quantifiers we *do* fold in the cases where the verdict is independent of
+  // the binding: an empty quantified domain, or a body that's a literal.
+  visitExpr(ctx: ExprContext): Abstract {
+    if (ctx.LET_TOK() || ctx.BIND_TOK()) return UNKNOWN;
+    const quant = ctx.quant();
+    if (quant) return this.foldQuantifier(ctx, quant);
+    return this.visitChildren(ctx);
+  }
+
+  private foldQuantifier(ctx: ExprContext, quant: QuantContext): Abstract {
+    const blockOrBar = ctx.blockOrBar();
+    if (!blockOrBar) return UNKNOWN;
+
+    // Determine if any quantified domain is statically empty.
+    let domainEmpty = false;
+    let declList = ctx.quantDeclList();
+    while (declList) {
+      const setExpr = declList.quantDecl().expr();
+      if (this.visit(setExpr).kind === "empty") {
+        domainEmpty = true;
+        break;
+      }
+      const next = declList.quantDeclList();
+      if (!next) break;
+      declList = next;
+    }
+
+    // Body analysis (only attempt the `| expr` form; blocks are conjunctions
+    // and would need the binding to be meaningful).
+    let body: Abstract = UNKNOWN;
+    if (blockOrBar.BAR_TOK() && blockOrBar.expr()) {
+      body = this.visit(blockOrBar.expr()!);
+    }
+
+    const mult = quant.mult();
+    const isAll = quant.ALL_TOK() !== undefined;
+    const isNo = quant.NO_TOK() !== undefined;
+    const isSome = mult?.SOME_TOK() !== undefined;
+    const isOne = mult?.ONE_TOK() !== undefined;
+    const isTwo = mult?.TWO_TOK() !== undefined;
+    const isLone = mult?.LONE_TOK() !== undefined;
+
+    if (domainEmpty) {
+      // ∀ over empty is vacuously true; ∃ over empty is false.
+      if (isAll || isNo || isLone) return { kind: "bool", value: true };
+      if (isSome || isOne || isTwo) return { kind: "bool", value: false };
+    }
+
+    if (body.kind === "bool") {
+      if (!body.value) {
+        // body always false: no x satisfies, regardless of domain
+        if (isNo || isLone) return { kind: "bool", value: true };
+        if (isSome || isOne || isTwo) return { kind: "bool", value: false };
+        // all x | false  →  data-dependent (vacuous if domain empty, else false)
+      } else {
+        // body always true: every x satisfies
+        if (isAll) return { kind: "bool", value: true };
+        // some/one/no etc. depend on domain size — data-dependent
+      }
+    }
+
+    return UNKNOWN;
+  }
+
+  // A block { e1; e2; ...; en } is a conjunction of its expressions.
+  visitBlock(ctx: BlockContext): Abstract {
+    let result: Abstract = { kind: "bool", value: true };
+    for (const e of ctx.expr()) {
+      const v = this.visit(e);
+      if (v.kind === "bool" && !v.value) return v;       // any false → false
+      if (v.kind !== "bool") result = UNKNOWN;            // forget the running true
+    }
+    return result;
+  }
+
+  visitExpr1(ctx: Expr1Context): Abstract {
+    if (ctx.OR_TOK()) {
+      const leftCtx = ctx.expr1()!;
+      const rightCtx = ctx.expr1_5()!;
+      // X or X  →  X
+      if (sameSubtree(leftCtx, rightCtx)) return this.visit(leftCtx);
+      const l = this.visit(leftCtx);
+      const r = this.visit(rightCtx);
+      if (l.kind === "bool" && l.value) return l;
+      if (r.kind === "bool" && r.value) return r;
+      if (l.kind === "bool" && r.kind === "bool") {
+        return { kind: "bool", value: l.value || r.value };
+      }
+      // X or not X  /  not X or X  →  true (classical tautology)
+      const lNeg = negationOperandText(leftCtx);
+      const rNeg = negationOperandText(rightCtx);
+      if (lNeg !== undefined && lNeg === rightCtx.text) return { kind: "bool", value: true };
+      if (rNeg !== undefined && rNeg === leftCtx.text) return { kind: "bool", value: true };
+      return UNKNOWN;
+    }
+    return this.visitChildren(ctx);
+  }
+
+  visitExpr1_5(ctx: Expr1_5Context): Abstract {
+    if (ctx.XOR_TOK()) {
+      const leftCtx = ctx.expr1_5()!;
+      const rightCtx = ctx.expr2()!;
+      // X xor X  →  false
+      if (sameSubtree(leftCtx, rightCtx)) return { kind: "bool", value: false };
+      const l = this.visit(leftCtx);
+      const r = this.visit(rightCtx);
+      if (l.kind === "bool" && r.kind === "bool") {
+        return { kind: "bool", value: l.value !== r.value };
+      }
+      return UNKNOWN;
+    }
+    return this.visitChildren(ctx);
+  }
+
+  visitExpr2(ctx: Expr2Context): Abstract {
+    if (ctx.IFF_TOK()) {
+      const leftCtx = ctx.expr2()!;
+      const rightCtx = ctx.expr3()!;
+      // X iff X  →  true
+      if (sameSubtree(leftCtx, rightCtx)) return { kind: "bool", value: true };
+      // X iff not X  /  not X iff X  →  false
+      const lNeg = negationOperandText(leftCtx);
+      const rNeg = negationOperandText(rightCtx);
+      if (lNeg !== undefined && lNeg === rightCtx.text) return { kind: "bool", value: false };
+      if (rNeg !== undefined && rNeg === leftCtx.text) return { kind: "bool", value: false };
+      const l = this.visit(leftCtx);
+      const r = this.visit(rightCtx);
+      if (l.kind === "bool" && r.kind === "bool") {
+        return { kind: "bool", value: l.value === r.value };
+      }
+      return UNKNOWN;
+    }
+    return this.visitChildren(ctx);
+  }
+
+  visitExpr3(ctx: Expr3Context): Abstract {
+    if (ctx.IMP_TOK()) {
+      const ant = this.visit(ctx.expr4()!);
+      const exprs3 = ctx.expr3();
+      // Implication or implication-with-else
+      if (ctx.ELSE_TOK()) {
+        // (cond) => then else else  : pick the branch when cond is known
+        if (ant.kind === "bool") {
+          const chosen = ant.value ? exprs3[0] : exprs3[1];
+          return this.visit(chosen);
+        }
+        return UNKNOWN;
+      }
+      // antecedent false → vacuously true
+      if (ant.kind === "bool" && !ant.value) return { kind: "bool", value: true };
+      const conseqCtx = exprs3[0]!;
+      const con = this.visit(conseqCtx);
+      // true => X  ≡  X
+      if (ant.kind === "bool" && ant.value) return con;
+      // _ => true  ≡  true
+      if (con.kind === "bool" && con.value) return con;
+      return UNKNOWN;
+    }
+    return this.visitChildren(ctx);
+  }
+
+  visitExpr4(ctx: Expr4Context): Abstract {
+    if (ctx.AND_TOK()) {
+      const leftCtx = ctx.expr4()!;
+      const rightCtx = ctx.expr4_5()!;
+      // X and X  →  X
+      if (sameSubtree(leftCtx, rightCtx)) return this.visit(leftCtx);
+      const l = this.visit(leftCtx);
+      const r = this.visit(rightCtx);
+      if (l.kind === "bool" && !l.value) return l;
+      if (r.kind === "bool" && !r.value) return r;
+      if (l.kind === "bool" && r.kind === "bool") {
+        return { kind: "bool", value: l.value && r.value };
+      }
+      // X and not X  /  not X and X  →  false
+      const lNeg = negationOperandText(leftCtx);
+      const rNeg = negationOperandText(rightCtx);
+      if (lNeg !== undefined && lNeg === rightCtx.text) return { kind: "bool", value: false };
+      if (rNeg !== undefined && rNeg === leftCtx.text) return { kind: "bool", value: false };
+      return UNKNOWN;
+    }
+    return this.visitChildren(ctx);
+  }
+
+  visitExpr5(ctx: Expr5Context): Abstract {
+    if (ctx.NEG_TOK()) {
+      const inner = this.visit(ctx.expr5()!);
+      if (inner.kind === "ill-typed") return inner;
+      if (inner.kind === "bool") return { kind: "bool", value: !inner.value };
+      return UNKNOWN;
+    }
+    // Temporal operators are not implemented; bail out conservatively.
+    if (
+      ctx.ALWAYS_TOK() ||
+      ctx.EVENTUALLY_TOK() ||
+      ctx.AFTER_TOK() ||
+      ctx.BEFORE_TOK() ||
+      ctx.ONCE_TOK() ||
+      ctx.HISTORICALLY_TOK()
+    ) {
+      return UNKNOWN;
+    }
+    return this.visitChildren(ctx);
+  }
+
+  visitExpr6(ctx: Expr6Context): Abstract {
+    const op = ctx.compareOp();
+    if (!op) return this.visitChildren(ctx);
+
+    const leftCtx = ctx.expr6()!;
+    const rightCtx = ctx.expr7()!;
+    const l = this.visit(leftCtx);
+    const r = this.visit(rightCtx);
+    const negate = ctx.NEG_TOK() !== undefined;
+    const opText = op.text;
+
+    const finalize = (value: boolean): Abstract => ({
+      kind: "bool",
+      value: negate ? !value : value,
+    });
+
+    // Same-subtree shortcuts hold regardless of unknown values.
+    if (sameSubtree(leftCtx, rightCtx)) {
+      switch (opText) {
+        case "=":
+        case "<=":
+        case ">=":
+        case "in":
+          return finalize(true);
+        case "<":
+        case ">":
+          return finalize(false);
+        case "ni":
+          // ni is "right contains left"; X ni X is also true.
+          return finalize(true);
+      }
+    }
+
+    // Numeric literal folding.
+    if (l.kind === "num" && r.kind === "num") {
+      switch (opText) {
+        case "=":
+          return finalize(l.value === r.value);
+        case "<":
+          return finalize(l.value < r.value);
+        case ">":
+          return finalize(l.value > r.value);
+        case "<=":
+          return finalize(l.value <= r.value);
+        case ">=":
+          return finalize(l.value >= r.value);
+      }
+    }
+
+    // Boolean literal equality.
+    if (l.kind === "bool" && r.kind === "bool" && opText === "=") {
+      return finalize(l.value === r.value);
+    }
+
+    // Empty / singleton comparisons.
+    const lIsKnownSingleton = l.kind === "num" || l.kind === "bool";
+    const rIsKnownSingleton = r.kind === "num" || r.kind === "bool";
+    if (opText === "=") {
+      if (l.kind === "empty" && r.kind === "empty") return finalize(true);
+      if (l.kind === "empty" && rIsKnownSingleton) return finalize(false);
+      if (lIsKnownSingleton && r.kind === "empty") return finalize(false);
+    }
+    if (opText === "in") {
+      // empty set is a subset of every set
+      if (l.kind === "empty") return finalize(true);
+      // a non-empty singleton cannot be contained in the empty set
+      if (lIsKnownSingleton && r.kind === "empty") return finalize(false);
+    }
+    if (opText === "ni") {
+      // ni is reverse containment: R ni L  ≡  L in R
+      if (r.kind === "empty") return finalize(true);
+      if (rIsKnownSingleton && l.kind === "empty") return finalize(false);
+    }
+
+    // Arity mismatch on arity-sensitive comparisons → ill-typed.
+    if (opText === "=" || opText === "in" || opText === "ni") {
+      const la = ForgeExprStaticAnalyzer.arityOf(l);
+      const ra = ForgeExprStaticAnalyzer.arityOf(r);
+      if (la > 0 && ra > 0 && la !== ra) {
+        return {
+          kind: "ill-typed",
+          reason: `arity mismatch in '${opText}': left has arity ${la}, right has arity ${ra}`,
+        };
+      }
+    }
+
+    // Schema-driven: subtype tautologies for `in` / `ni`, and disjoint-type
+    // unsat for `=` between two unary type sets.
+    if (this.schema && l.kind === "typed" && r.kind === "typed") {
+      const lCols = l.columnTypes;
+      const rCols = r.columnTypes;
+      if (lCols && rCols && lCols.length === rCols.length) {
+        const colWiseSubtype = lCols.every((lc, i) => this.schema!.isSubtypeOf(lc, rCols[i]));
+        const colWiseSupertype = lCols.every((lc, i) => this.schema!.isSubtypeOf(rCols[i], lc));
+        if (opText === "in" && colWiseSubtype) return finalize(true);
+        if (opText === "ni" && colWiseSupertype) return finalize(true);
+      }
+    }
+
+    return UNKNOWN;
+  }
+
+  visitExpr7(ctx: Expr7Context): Abstract {
+    const inner = this.visit(ctx.expr8());
+    if (inner.kind === "ill-typed") return inner;
+
+    if (ctx.SET_TOK()) return inner;
+
+    if (inner.kind === "empty") {
+      if (ctx.NO_TOK()) return { kind: "bool", value: true };
+      if (ctx.LONE_TOK()) return { kind: "bool", value: true };
+      if (ctx.SOME_TOK()) return { kind: "bool", value: false };
+      if (ctx.ONE_TOK()) return { kind: "bool", value: false };
+      if (ctx.TWO_TOK()) return { kind: "bool", value: false };
+    }
+
+    // If we can't say anything specific about the multiplicity, the whole
+    // expression is still a boolean — but its value is unknown.
+    if (
+      ctx.NO_TOK() ||
+      ctx.LONE_TOK() ||
+      ctx.SOME_TOK() ||
+      ctx.ONE_TOK() ||
+      ctx.TWO_TOK()
+    ) {
+      return UNKNOWN;
+    }
+
+    return inner;
+  }
+
+  visitExpr8(ctx: Expr8Context): Abstract {
+    if (ctx.MINUS_TOK()) {
+      const leftCtx = ctx.expr8()!;
+      const rightCtx = ctx.expr10()!;
+      // X - X  →  empty (set difference) or 0 (numeric)
+      if (sameSubtree(leftCtx, rightCtx)) {
+        const l = this.visit(leftCtx);
+        if (l.kind === "num") return { kind: "num", value: 0 };
+        return { kind: "empty" };
+      }
+      const l = this.visit(leftCtx);
+      const r = this.visit(rightCtx);
+      // Numeric folding for literal subtraction.
+      if (l.kind === "num" && r.kind === "num") {
+        return { kind: "num", value: l.value - r.value };
+      }
+      // empty - X  →  empty;  X - empty  →  X
+      if (l.kind === "empty") return { kind: "empty" };
+      if (r.kind === "empty") return l;
+      // Subset patterns: L ⊆ R  ⇒  L - R = empty.
+      //   (R & ?) - R   or   (? & R) - R     (intersection is a subset)
+      if (intersectionInvolves(leftCtx, rightCtx.text)) return { kind: "empty" };
+      //   L - (L + ?)   or   L - (? + L)     (L is a subset of the union)
+      if (unionContains(rightCtx, leftCtx.text)) return { kind: "empty" };
+      // Arity mismatch is a static type error.
+      const lArity = ForgeExprStaticAnalyzer.arityOf(l);
+      const rArity = ForgeExprStaticAnalyzer.arityOf(r);
+      if (lArity > 0 && rArity > 0 && lArity !== rArity) {
+        return {
+          kind: "ill-typed",
+          reason: `arity mismatch in '-': left has arity ${lArity}, right has arity ${rArity}`,
+        };
+      }
+      return UNKNOWN;
+    }
+    if (ctx.PLUS_TOK()) {
+      const l = this.visit(ctx.expr8()!);
+      const r = this.visit(ctx.expr10()!);
+      // Numeric literal addition.
+      if (l.kind === "num" && r.kind === "num") {
+        return { kind: "num", value: l.value + r.value };
+      }
+      // Empty is the identity of set union: X + none ≡ X, none + X ≡ X.
+      if (l.kind === "empty" && r.kind === "empty") return { kind: "empty" };
+      if (l.kind === "empty") return r;
+      if (r.kind === "empty") return l;
+      // Arity mismatch is a static type error.
+      const lArity = ForgeExprStaticAnalyzer.arityOf(l);
+      const rArity = ForgeExprStaticAnalyzer.arityOf(r);
+      if (lArity > 0 && rArity > 0 && lArity !== rArity) {
+        return {
+          kind: "ill-typed",
+          reason: `arity mismatch in '+': left has arity ${lArity}, right has arity ${rArity}`,
+        };
+      }
+      if (lArity > 0 && rArity > 0) {
+        return { kind: "typed", arity: lArity };
+      }
+      return UNKNOWN;
+    }
+    return this.visitChildren(ctx);
+  }
+
+  visitExpr9(ctx: Expr9Context): Abstract {
+    if (ctx.CARD_TOK()) {
+      const inner = this.visit(ctx.expr9()!);
+      if (inner.kind === "ill-typed") return inner;
+      if (inner.kind === "empty") return { kind: "num", value: 0 };
+      return UNKNOWN;
+    }
+    return this.visitChildren(ctx);
+  }
+
+  visitExpr12(ctx: Expr12Context): Abstract {
+    if (ctx.arrowOp()) {
+      // Cartesian product: if either side is empty, the product is empty.
+      const l = this.visit(ctx.expr12()!);
+      const r = this.visit(ctx.expr13()!);
+      if (l.kind === "empty" || r.kind === "empty") return { kind: "empty" };
+      // Propagate combined arity / column types.
+      if (l.kind === "typed" && r.kind === "typed") {
+        const cols =
+          l.columnTypes && r.columnTypes
+            ? [...l.columnTypes, ...r.columnTypes]
+            : undefined;
+        return { kind: "typed", arity: l.arity + r.arity, columnTypes: cols };
+      }
+      const la = ForgeExprStaticAnalyzer.arityOf(l);
+      const ra = ForgeExprStaticAnalyzer.arityOf(r);
+      if (la > 0 && ra > 0) return { kind: "typed", arity: la + ra };
+      return UNKNOWN;
+    }
+    return this.visitChildren(ctx);
+  }
+
+  visitExpr11(ctx: Expr11Context): Abstract {
+    if (ctx.AMP_TOK()) {
+      const leftCtx = ctx.expr11()!;
+      const rightCtx = ctx.expr12()!;
+      // X & X  →  X (preserve "empty" if we know it; otherwise unknown).
+      if (sameSubtree(leftCtx, rightCtx)) {
+        return this.visit(leftCtx);
+      }
+      const l = this.visit(leftCtx);
+      const r = this.visit(rightCtx);
+      // empty & anything  →  empty
+      if (l.kind === "empty" || r.kind === "empty") return { kind: "empty" };
+      // Distinct numeric singletons are disjoint sets.
+      if (l.kind === "num" && r.kind === "num" && l.value !== r.value) {
+        return { kind: "empty" };
+      }
+      // X & (... - X)  →  empty (subtrahend strips X out).
+      if (subtractsTarget(rightCtx, leftCtx.text)) return { kind: "empty" };
+      if (subtractsTarget(leftCtx, rightCtx.text)) return { kind: "empty" };
+      // Arity mismatch → ill-typed.
+      const la = ForgeExprStaticAnalyzer.arityOf(l);
+      const ra = ForgeExprStaticAnalyzer.arityOf(r);
+      if (la > 0 && ra > 0 && la !== ra) {
+        return {
+          kind: "ill-typed",
+          reason: `arity mismatch in '&': left has arity ${la}, right has arity ${ra}`,
+        };
+      }
+      // Schema-driven column-wise disjointness.
+      if (this.schema && l.kind === "typed" && r.kind === "typed" && l.columnTypes && r.columnTypes) {
+        if (l.columnTypes.length === r.columnTypes.length) {
+          const anyDisjoint = l.columnTypes.some((lc, i) =>
+            this.schema!.areDisjoint(lc, r.columnTypes![i])
+          );
+          if (anyDisjoint) return { kind: "empty" };
+        }
+      }
+      return UNKNOWN;
+    }
+    return this.visitChildren(ctx);
+  }
+
+  visitExpr14(ctx: Expr14Context): Abstract {
+    if (ctx.LEFT_SQUARE_TOK()) {
+      // Box join f[a, b, ...]  ≡  ...b.a.f
+      const fn = this.visit(ctx.expr14()!);
+      if (fn.kind === "empty") return { kind: "empty" };
+      // walk the comma-separated argument list
+      let list = ctx.exprList();
+      while (list) {
+        const arg = this.visit(list.expr());
+        if (arg.kind === "empty") return { kind: "empty" };
+        list = list.exprList();
+      }
+      return UNKNOWN;
+    }
+    return this.visitChildren(ctx);
+  }
+
+  visitExpr15(ctx: Expr15Context): Abstract {
+    if (ctx.DOT_TOK()) {
+      const l = this.visit(ctx.expr15()!);
+      const r = this.visit(ctx.expr16()!);
+      if (l.kind === "empty" || r.kind === "empty") return { kind: "empty" };
+      // Joining two singletons / unary expressions yields arity 0 — ill-typed.
+      const la = ForgeExprStaticAnalyzer.arityOf(l);
+      const ra = ForgeExprStaticAnalyzer.arityOf(r);
+      if (la === 1 && ra === 1) {
+        return {
+          kind: "ill-typed",
+          reason: "dot join of two unary expressions produces arity 0",
+        };
+      }
+      // Schema-aware column-type check on the join boundary.
+      if (
+        this.schema &&
+        l.kind === "typed" && r.kind === "typed" &&
+        l.columnTypes && r.columnTypes &&
+        l.columnTypes.length > 0 && r.columnTypes.length > 0
+      ) {
+        const leftLast = l.columnTypes[l.columnTypes.length - 1];
+        const rightFirst = r.columnTypes[0];
+        if (this.schema.areDisjoint(leftLast, rightFirst)) {
+          return { kind: "empty" };
+        }
+        // Propagate typed-ness through the join when possible.
+        const newCols = [
+          ...l.columnTypes.slice(0, -1),
+          ...r.columnTypes.slice(1),
+        ];
+        if (newCols.length > 0) {
+          return { kind: "typed", arity: newCols.length, columnTypes: newCols };
+        }
+      }
+      // Otherwise propagate arity if we have it on both sides.
+      if (la > 0 && ra > 0) {
+        return { kind: "typed", arity: la + ra - 2 };
+      }
+      return UNKNOWN;
+    }
+    // name LEFT_SQUARE_TOK exprList RIGHT_SQUARE_TOK is a named pred call —
+    // body unknown, so we can't fold even if args are empty.
+    if (ctx.LEFT_SQUARE_TOK()) return UNKNOWN;
+    return this.visitChildren(ctx);
+  }
+
+  visitExpr17(ctx: Expr17Context): Abstract {
+    if (ctx.TILDE_TOK() || ctx.EXP_TOK()) {
+      // transpose ~X and transitive closure ^X both preserve emptiness
+      const inner = this.visit(ctx.expr17()!);
+      if (inner.kind === "ill-typed") return inner;
+      if (inner.kind === "empty") return { kind: "empty" };
+      return UNKNOWN;
+    }
+    if (ctx.STAR_TOK()) {
+      // reflexive transitive closure *X = iden ∪ ^X — *none = iden, which is
+      // generally non-empty, so we cannot conclude empty here.
+      return UNKNOWN;
+    }
+    if (
+      ctx.GET_LABEL_TOK() ||
+      ctx.GET_LABEL_STR_TOK() ||
+      ctx.GET_LABEL_BOOL_TOK() ||
+      ctx.GET_LABEL_NUM_TOK()
+    ) {
+      // Label lookups depend on per-atom labels in the data instance.
+      return UNKNOWN;
+    }
+    return this.visitChildren(ctx);
+  }
+
+  visitExpr18(ctx: Expr18Context): Abstract {
+    if (ctx.LEFT_PAREN_TOK()) {
+      return this.visit(ctx.expr()!);
+    }
+    if (ctx.const()) {
+      const c = ctx.const()!;
+      if (c.NONE_TOK()) return { kind: "empty" };
+      if (c.number()) {
+        const n = Number(c.number()!.text);
+        const value = c.MINUS_TOK() ? -n : n;
+        return { kind: "num", value };
+      }
+      // iden, univ are data-dependent
+      return UNKNOWN;
+    }
+    if (ctx.qualName()) {
+      // qualName resolves to either INT_TOK / SUM_TOK (data-dependent) or a
+      // plain name — descend so visitName can fold `true` / `false`.
+      return this.visit(ctx.qualName()!);
+    }
+    if (ctx.LEFT_CURLY_TOK()) {
+      // Set comprehension `{x : S | body}` is empty if any quantified set is
+      // empty, or if the body is statically false.
+      const declList = ctx.quantDeclList();
+      if (declList) {
+        let cur = declList;
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        while (cur) {
+          const setExpr = cur.quantDecl().expr();
+          const v = this.visit(setExpr);
+          if (v.kind === "empty") return { kind: "empty" };
+          const next = cur.quantDeclList();
+          if (!next) break;
+          cur = next;
+        }
+      }
+      const blockOrBar = ctx.blockOrBar();
+      if (blockOrBar && blockOrBar.BAR_TOK() && blockOrBar.expr()) {
+        const body = this.visit(blockOrBar.expr()!);
+        if (body.kind === "bool" && !body.value) return { kind: "empty" };
+      }
+      return UNKNOWN;
+    }
+    if (ctx.block()) {
+      return this.visit(ctx.block()!);
+    }
+    // sexpr, AT_TOK, BACKQUOTE_TOK, THIS_TOK — unsupported.
+    return UNKNOWN;
+  }
+
+  // `true` / `false` are parsed as names rather than `const` literals — the
+  // evaluator handles them in visitName, so we do the same. When a schema is
+  // available, type and relation names resolve to `typed` with arity and
+  // column types from the schema.
+  visitName(ctx: NameContext): Abstract {
+    const id = getIdentifierName(ctx);
+    if (id === "true") return { kind: "bool", value: true };
+    if (id === "false") return { kind: "bool", value: false };
+    if (this.schema) {
+      const t = this.schema.getType(id);
+      if (t) return { kind: "typed", arity: 1, columnTypes: [t.id] };
+      const r = this.schema.getRelation(id);
+      if (r) {
+        const cols = r.types;
+        return { kind: "typed", arity: cols.length, columnTypes: cols };
+      }
+    }
+    return UNKNOWN;
+  }
+}

--- a/src/ForgeExprStaticAnalyzer.ts
+++ b/src/ForgeExprStaticAnalyzer.ts
@@ -242,6 +242,17 @@ export class ForgeExprStaticAnalyzer
     return UNKNOWN;
   }
 
+  // Return the first ill-typed value among the args, or undefined. Used by
+  // every operator handler to surface a statically malformed sub-expression
+  // before any fold (including short-circuits like `false AND ?` and `true OR
+  // ?`) could mask it.
+  private static bailIfIllTyped(...vals: Abstract[]): Abstract | undefined {
+    for (const v of vals) {
+      if (v.kind === "ill-typed") return v;
+    }
+    return undefined;
+  }
+
   // Prefer the more specific child result when aggregating across siblings.
   // For pass-through expr layers there's exactly one meaningful child; for
   // wrapper nodes like `( expr )` the terminals contribute UNKNOWN and the
@@ -336,7 +347,8 @@ export class ForgeExprStaticAnalyzer
     let result: Abstract = { kind: "bool", value: true };
     for (const e of ctx.expr()) {
       const v = this.visit(e);
-      if (v.kind === "bool" && !v.value) return v;       // any false → false
+      if (v.kind === "ill-typed") return v;               // ill-typed wins
+      if (v.kind === "bool" && !v.value) return v;        // any false → false
       if (v.kind !== "bool") result = UNKNOWN;            // forget the running true
     }
     return result;
@@ -346,10 +358,12 @@ export class ForgeExprStaticAnalyzer
     if (ctx.OR_TOK()) {
       const leftCtx = ctx.expr1()!;
       const rightCtx = ctx.expr1_5()!;
-      // X or X  →  X
-      if (sameSubtree(leftCtx, rightCtx)) return this.visit(leftCtx);
       const l = this.visit(leftCtx);
       const r = this.visit(rightCtx);
+      const bail = ForgeExprStaticAnalyzer.bailIfIllTyped(l, r);
+      if (bail) return bail;
+      // X or X  →  X
+      if (sameSubtree(leftCtx, rightCtx)) return l;
       if (l.kind === "bool" && l.value) return l;
       if (r.kind === "bool" && r.value) return r;
       if (l.kind === "bool" && r.kind === "bool") {
@@ -369,10 +383,12 @@ export class ForgeExprStaticAnalyzer
     if (ctx.XOR_TOK()) {
       const leftCtx = ctx.expr1_5()!;
       const rightCtx = ctx.expr2()!;
-      // X xor X  →  false
-      if (sameSubtree(leftCtx, rightCtx)) return { kind: "bool", value: false };
       const l = this.visit(leftCtx);
       const r = this.visit(rightCtx);
+      const bail = ForgeExprStaticAnalyzer.bailIfIllTyped(l, r);
+      if (bail) return bail;
+      // X xor X  →  false
+      if (sameSubtree(leftCtx, rightCtx)) return { kind: "bool", value: false };
       if (l.kind === "bool" && r.kind === "bool") {
         return { kind: "bool", value: l.value !== r.value };
       }
@@ -385,6 +401,10 @@ export class ForgeExprStaticAnalyzer
     if (ctx.IFF_TOK()) {
       const leftCtx = ctx.expr2()!;
       const rightCtx = ctx.expr3()!;
+      const l = this.visit(leftCtx);
+      const r = this.visit(rightCtx);
+      const bail = ForgeExprStaticAnalyzer.bailIfIllTyped(l, r);
+      if (bail) return bail;
       // X iff X  →  true
       if (sameSubtree(leftCtx, rightCtx)) return { kind: "bool", value: true };
       // X iff not X  /  not X iff X  →  false
@@ -392,8 +412,6 @@ export class ForgeExprStaticAnalyzer
       const rNeg = negationOperandText(rightCtx);
       if (lNeg !== undefined && lNeg === rightCtx.text) return { kind: "bool", value: false };
       if (rNeg !== undefined && rNeg === leftCtx.text) return { kind: "bool", value: false };
-      const l = this.visit(leftCtx);
-      const r = this.visit(rightCtx);
       if (l.kind === "bool" && r.kind === "bool") {
         return { kind: "bool", value: l.value === r.value };
       }
@@ -406,19 +424,23 @@ export class ForgeExprStaticAnalyzer
     if (ctx.IMP_TOK()) {
       const ant = this.visit(ctx.expr4()!);
       const exprs3 = ctx.expr3();
-      // Implication or implication-with-else
+      // Implication or implication-with-else. Visit all branches up front so
+      // an ill-typed sub-expression is reported even when a short-circuit
+      // (false antecedent, etc.) would otherwise fold the verdict.
       if (ctx.ELSE_TOK()) {
-        // (cond) => then else else  : pick the branch when cond is known
-        if (ant.kind === "bool") {
-          const chosen = ant.value ? exprs3[0] : exprs3[1];
-          return this.visit(chosen);
-        }
+        const thenBranch = this.visit(exprs3[0]);
+        const elseBranch = this.visit(exprs3[1]);
+        const bail = ForgeExprStaticAnalyzer.bailIfIllTyped(ant, thenBranch, elseBranch);
+        if (bail) return bail;
+        if (ant.kind === "bool") return ant.value ? thenBranch : elseBranch;
         return UNKNOWN;
       }
-      // antecedent false → vacuously true
-      if (ant.kind === "bool" && !ant.value) return { kind: "bool", value: true };
       const conseqCtx = exprs3[0]!;
       const con = this.visit(conseqCtx);
+      const bail = ForgeExprStaticAnalyzer.bailIfIllTyped(ant, con);
+      if (bail) return bail;
+      // antecedent false → vacuously true
+      if (ant.kind === "bool" && !ant.value) return { kind: "bool", value: true };
       // true => X  ≡  X
       if (ant.kind === "bool" && ant.value) return con;
       // _ => true  ≡  true
@@ -432,10 +454,12 @@ export class ForgeExprStaticAnalyzer
     if (ctx.AND_TOK()) {
       const leftCtx = ctx.expr4()!;
       const rightCtx = ctx.expr4_5()!;
-      // X and X  →  X
-      if (sameSubtree(leftCtx, rightCtx)) return this.visit(leftCtx);
       const l = this.visit(leftCtx);
       const r = this.visit(rightCtx);
+      const bail = ForgeExprStaticAnalyzer.bailIfIllTyped(l, r);
+      if (bail) return bail;
+      // X and X  →  X
+      if (sameSubtree(leftCtx, rightCtx)) return l;
       if (l.kind === "bool" && !l.value) return l;
       if (r.kind === "bool" && !r.value) return r;
       if (l.kind === "bool" && r.kind === "bool") {
@@ -480,17 +504,28 @@ export class ForgeExprStaticAnalyzer
     const rightCtx = ctx.expr7()!;
     const l = this.visit(leftCtx);
     const r = this.visit(rightCtx);
+    const bail = ForgeExprStaticAnalyzer.bailIfIllTyped(l, r);
+    if (bail) return bail;
     const negate = ctx.NEG_TOK() !== undefined;
     const opText = op.text;
 
-    const finalize = (value: boolean): Abstract => ({
-      kind: "bool",
-      value: negate ? !value : value,
-    });
+    // `ni` is non-membership (the codebase's evaluator implements it as
+    // !(in)). We fold it by computing the corresponding `in` verdict and
+    // letting `finalize` invert. This keeps the static verdict in agreement
+    // with runtime semantics for expressions like `X ni X` (false) and
+    // `none ni 1` (true).
+    const isNi = opText === "ni";
+    const opForLogic = isNi ? "in" : opText;
+    const finalize = (value: boolean): Abstract => {
+      let v = value;
+      if (isNi) v = !v;
+      if (negate) v = !v;
+      return { kind: "bool", value: v };
+    };
 
     // Same-subtree shortcuts hold regardless of unknown values.
     if (sameSubtree(leftCtx, rightCtx)) {
-      switch (opText) {
+      switch (opForLogic) {
         case "=":
         case "<=":
         case ">=":
@@ -499,15 +534,12 @@ export class ForgeExprStaticAnalyzer
         case "<":
         case ">":
           return finalize(false);
-        case "ni":
-          // ni is "right contains left"; X ni X is also true.
-          return finalize(true);
       }
     }
 
     // Numeric literal folding.
     if (l.kind === "num" && r.kind === "num") {
-      switch (opText) {
+      switch (opForLogic) {
         case "=":
           return finalize(l.value === r.value);
         case "<":
@@ -522,28 +554,23 @@ export class ForgeExprStaticAnalyzer
     }
 
     // Boolean literal equality.
-    if (l.kind === "bool" && r.kind === "bool" && opText === "=") {
+    if (l.kind === "bool" && r.kind === "bool" && opForLogic === "=") {
       return finalize(l.value === r.value);
     }
 
     // Empty / singleton comparisons.
     const lIsKnownSingleton = l.kind === "num" || l.kind === "bool";
     const rIsKnownSingleton = r.kind === "num" || r.kind === "bool";
-    if (opText === "=") {
+    if (opForLogic === "=") {
       if (l.kind === "empty" && r.kind === "empty") return finalize(true);
       if (l.kind === "empty" && rIsKnownSingleton) return finalize(false);
       if (lIsKnownSingleton && r.kind === "empty") return finalize(false);
     }
-    if (opText === "in") {
+    if (opForLogic === "in") {
       // empty set is a subset of every set
       if (l.kind === "empty") return finalize(true);
       // a non-empty singleton cannot be contained in the empty set
       if (lIsKnownSingleton && r.kind === "empty") return finalize(false);
-    }
-    if (opText === "ni") {
-      // ni is reverse containment: R ni L  ≡  L in R
-      if (r.kind === "empty") return finalize(true);
-      if (rIsKnownSingleton && l.kind === "empty") return finalize(false);
     }
 
     // Arity mismatch on arity-sensitive comparisons → ill-typed.
@@ -558,16 +585,16 @@ export class ForgeExprStaticAnalyzer
       }
     }
 
-    // Schema-driven: subtype tautologies for `in` / `ni`, and disjoint-type
-    // unsat for `=` between two unary type sets.
+    // Schema-driven: subtype tautologies for `in` (and `ni` via finalize
+    // inversion when A ⊆ B → A in B is true → A ni B is false). We
+    // deliberately do NOT positively fold `ni` from the lattice — concluding
+    // "not (A ⊆ B)" requires disjointness reasoning we don't perform here.
     if (this.schema && l.kind === "typed" && r.kind === "typed") {
       const lCols = l.columnTypes;
       const rCols = r.columnTypes;
       if (lCols && rCols && lCols.length === rCols.length) {
         const colWiseSubtype = lCols.every((lc, i) => this.schema!.isSubtypeOf(lc, rCols[i]));
-        const colWiseSupertype = lCols.every((lc, i) => this.schema!.isSubtypeOf(rCols[i], lc));
-        if (opText === "in" && colWiseSubtype) return finalize(true);
-        if (opText === "ni" && colWiseSupertype) return finalize(true);
+        if (opForLogic === "in" && colWiseSubtype) return finalize(true);
       }
     }
 
@@ -607,14 +634,15 @@ export class ForgeExprStaticAnalyzer
     if (ctx.MINUS_TOK()) {
       const leftCtx = ctx.expr8()!;
       const rightCtx = ctx.expr10()!;
+      const l = this.visit(leftCtx);
+      const r = this.visit(rightCtx);
+      const bail = ForgeExprStaticAnalyzer.bailIfIllTyped(l, r);
+      if (bail) return bail;
       // X - X  →  empty (set difference) or 0 (numeric)
       if (sameSubtree(leftCtx, rightCtx)) {
-        const l = this.visit(leftCtx);
         if (l.kind === "num") return { kind: "num", value: 0 };
         return { kind: "empty" };
       }
-      const l = this.visit(leftCtx);
-      const r = this.visit(rightCtx);
       // Numeric folding for literal subtraction.
       if (l.kind === "num" && r.kind === "num") {
         return { kind: "num", value: l.value - r.value };
@@ -641,6 +669,8 @@ export class ForgeExprStaticAnalyzer
     if (ctx.PLUS_TOK()) {
       const l = this.visit(ctx.expr8()!);
       const r = this.visit(ctx.expr10()!);
+      const bail = ForgeExprStaticAnalyzer.bailIfIllTyped(l, r);
+      if (bail) return bail;
       // Numeric literal addition.
       if (l.kind === "num" && r.kind === "num") {
         return { kind: "num", value: l.value + r.value };
@@ -681,6 +711,8 @@ export class ForgeExprStaticAnalyzer
       // Cartesian product: if either side is empty, the product is empty.
       const l = this.visit(ctx.expr12()!);
       const r = this.visit(ctx.expr13()!);
+      const bail = ForgeExprStaticAnalyzer.bailIfIllTyped(l, r);
+      if (bail) return bail;
       if (l.kind === "empty" || r.kind === "empty") return { kind: "empty" };
       // Propagate combined arity / column types.
       if (l.kind === "typed" && r.kind === "typed") {
@@ -702,12 +734,12 @@ export class ForgeExprStaticAnalyzer
     if (ctx.AMP_TOK()) {
       const leftCtx = ctx.expr11()!;
       const rightCtx = ctx.expr12()!;
-      // X & X  →  X (preserve "empty" if we know it; otherwise unknown).
-      if (sameSubtree(leftCtx, rightCtx)) {
-        return this.visit(leftCtx);
-      }
       const l = this.visit(leftCtx);
       const r = this.visit(rightCtx);
+      const bail = ForgeExprStaticAnalyzer.bailIfIllTyped(l, r);
+      if (bail) return bail;
+      // X & X  →  X (preserve "empty" if we know it; otherwise unknown).
+      if (sameSubtree(leftCtx, rightCtx)) return l;
       // empty & anything  →  empty
       if (l.kind === "empty" || r.kind === "empty") return { kind: "empty" };
       // Distinct numeric singletons are disjoint sets.
@@ -744,11 +776,13 @@ export class ForgeExprStaticAnalyzer
     if (ctx.LEFT_SQUARE_TOK()) {
       // Box join f[a, b, ...]  ≡  ...b.a.f
       const fn = this.visit(ctx.expr14()!);
+      if (fn.kind === "ill-typed") return fn;
       if (fn.kind === "empty") return { kind: "empty" };
       // walk the comma-separated argument list
       let list = ctx.exprList();
       while (list) {
         const arg = this.visit(list.expr());
+        if (arg.kind === "ill-typed") return arg;
         if (arg.kind === "empty") return { kind: "empty" };
         list = list.exprList();
       }
@@ -761,6 +795,8 @@ export class ForgeExprStaticAnalyzer
     if (ctx.DOT_TOK()) {
       const l = this.visit(ctx.expr15()!);
       const r = this.visit(ctx.expr16()!);
+      const bail = ForgeExprStaticAnalyzer.bailIfIllTyped(l, r);
+      if (bail) return bail;
       if (l.kind === "empty" || r.kind === "empty") return { kind: "empty" };
       // Joining two singletons / unary expressions yields arity 0 — ill-typed.
       const la = ForgeExprStaticAnalyzer.arityOf(l);

--- a/src/ForgeExprStaticAnalyzer.ts
+++ b/src/ForgeExprStaticAnalyzer.ts
@@ -20,6 +20,8 @@ import {
   Expr18Context,
   ExprContext,
   NameContext,
+  NameListContext,
+  QuantDeclListContext,
   BlockContext,
   QuantContext,
 } from "./forge-antlr/ForgeParser";
@@ -173,10 +175,47 @@ export class ForgeExprStaticAnalyzer
   implements ForgeVisitor<Abstract>
 {
   private readonly schema?: SchemaInfo;
+  // Stack of name-binding frames introduced by enclosing scopes (set
+  // comprehensions today; quantifiers/let when they get analyzed). A name
+  // appearing in any frame must not be looked up in the schema — its value
+  // is whatever the binder supplies, which we cannot reason about statically.
+  private readonly boundScopes: Array<Set<string>> = [];
 
   constructor(schema?: IForgeSchema) {
     super();
     if (schema) this.schema = new SchemaInfo(schema);
+  }
+
+  private isBound(name: string): boolean {
+    for (const frame of this.boundScopes) {
+      if (frame.has(name)) return true;
+    }
+    return false;
+  }
+
+  // Run `fn` with `names` pushed onto the scope stack. try/finally so a thrown
+  // visit doesn't leak frames into sibling analyses.
+  private withBoundScope<T>(names: Set<string>, fn: () => T): T {
+    this.boundScopes.push(names);
+    try {
+      return fn();
+    } finally {
+      this.boundScopes.pop();
+    }
+  }
+
+  // Walk a nameList (`a, b, c`) and accumulate identifiers into `out`.
+  private collectNamesFromList(ctx: NameListContext, out: Set<string>): void {
+    out.add(getIdentifierName(ctx.name()));
+    const tail = ctx.nameList();
+    if (tail) this.collectNamesFromList(tail, out);
+  }
+
+  // Walk a quantDeclList (`a : S, b : T`) and accumulate all bound identifiers.
+  private collectBoundNames(ctx: QuantDeclListContext, out: Set<string>): void {
+    this.collectNamesFromList(ctx.quantDecl().nameList(), out);
+    const tail = ctx.quantDeclList();
+    if (tail) this.collectBoundNames(tail, out);
   }
 
   // Public entry: convert internal lattice value to a verdict + reason.
@@ -805,8 +844,11 @@ export class ForgeExprStaticAnalyzer
     }
     if (ctx.LEFT_CURLY_TOK()) {
       // Set comprehension `{x : S | body}` is empty if any quantified set is
-      // empty, or if the body is statically false.
+      // empty, or if the body is statically false. Domain expressions evaluate
+      // in the OUTER scope (the variable isn't bound yet for its own domain),
+      // so we only need to push a scope before visiting the body.
       const declList = ctx.quantDeclList();
+      const boundHere = new Set<string>();
       if (declList) {
         let cur = declList;
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
@@ -814,6 +856,7 @@ export class ForgeExprStaticAnalyzer
           const setExpr = cur.quantDecl().expr();
           const v = this.visit(setExpr);
           if (v.kind === "empty") return { kind: "empty" };
+          this.collectNamesFromList(cur.quantDecl().nameList(), boundHere);
           const next = cur.quantDeclList();
           if (!next) break;
           cur = next;
@@ -821,7 +864,9 @@ export class ForgeExprStaticAnalyzer
       }
       const blockOrBar = ctx.blockOrBar();
       if (blockOrBar && blockOrBar.BAR_TOK() && blockOrBar.expr()) {
-        const body = this.visit(blockOrBar.expr()!);
+        const body = this.withBoundScope(boundHere, () =>
+          this.visit(blockOrBar.expr()!),
+        );
         if (body.kind === "bool" && !body.value) return { kind: "empty" };
       }
       return UNKNOWN;
@@ -841,6 +886,9 @@ export class ForgeExprStaticAnalyzer
     const id = getIdentifierName(ctx);
     if (id === "true") return { kind: "bool", value: true };
     if (id === "false") return { kind: "bool", value: false };
+    // If this name is shadowed by an enclosing binder, we cannot reason about
+    // it from the schema — the bound value can be anything.
+    if (this.isBound(id)) return UNKNOWN;
     if (this.schema) {
       const t = this.schema.getType(id);
       if (t) return { kind: "typed", arity: 1, columnTypes: [t.id] };

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,8 @@ import { ForgeLexer } from './forge-antlr/ForgeLexer';
 import { ForgeListenerImpl } from './forge-antlr/ForgeListenerImpl';
 import { ParseTreeWalker } from 'antlr4ts/tree/ParseTreeWalker';
 import { EvalResult, ForgeExprEvaluator, NameNotFoundError } from './ForgeExprEvaluator';
-import { IDataInstance, IAtom, IRelation, ITuple, IType } from './types';
+import { ForgeExprStaticAnalyzer, StaticAnalysis } from './ForgeExprStaticAnalyzer';
+import { IDataInstance, IForgeSchema, IAtom, IRelation, ITuple, IType } from './types';
 import { ParseErrorListener } from './errorListener';
 
 export type ErrorResult = {
@@ -101,6 +102,39 @@ export class SimpleGraphQueryEvaluator {
     }
   }
 }
+
+/**
+ * Run a static analysis on a Forge expression.
+ *
+ * Returns `unsat` when the expression provably reduces to `false`, `empty`
+ * when it provably reduces to the empty set, `tautology` when it provably
+ * reduces to `true`, `ill-typed` for static type errors (e.g. arity
+ * mismatch), and `unknown` otherwise (including parse errors).
+ *
+ * When `schema` is provided, the analyzer also uses the type lattice and
+ * relation declarations to detect type-disjoint intersections, subtype
+ * tautologies in `in`, join column-type mismatches, and arity errors.
+ * Disjointness uses a closed-world rule (A ∩ B = ∅ iff no type in the
+ * lattice has both A and B in its lineage).
+ */
+export function analyzeForgeExpression(
+  forgeExpr: string,
+  schema?: IForgeSchema,
+): StaticAnalysis {
+  try {
+    const parser = createForgeParser(forgeExpr);
+    const tree = parser.parseExpr();
+    if (!tree || tree.childCount === 0) {
+      return { status: "unknown" };
+    }
+    return new ForgeExprStaticAnalyzer(schema).analyze(tree);
+  } catch {
+    return { status: "unknown" };
+  }
+}
+
+export { ForgeExprStaticAnalyzer, StaticAnalysis };
+export type { IForgeSchema };
 
 export {
   synthesizeSelector,

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,5 +40,14 @@ export interface IDataInstance {
     getAtomType(id: string): IType;
     getTypes(): readonly IType[];
     getAtoms(): readonly IAtom[];
-    getRelations(): readonly IRelation[]; 
+    getRelations(): readonly IRelation[];
+}
+
+// Schema-only view: just the type lattice and relation declarations, no
+// instance data. IDataInstance is structurally a superset, so any data
+// instance is also a schema. Used by the static analyzer for type-based
+// checks that don't need atoms/tuples.
+export interface IForgeSchema {
+    getTypes(): readonly IType[];
+    getRelations(): readonly IRelation[];
 }

--- a/test/static-analyzer.test.ts
+++ b/test/static-analyzer.test.ts
@@ -495,37 +495,42 @@ describe("ForgeExprStaticAnalyzer — schema-aware: arity mismatches", () => {
   });
 });
 
-describe("ForgeExprStaticAnalyzer — shadowing safety", () => {
-  it("does not use schema info for set-comp bound names that shadow types", () => {
-    // `Player` is bound by the comprehension to range over Move atoms; in the
-    // body it has NOTHING to do with the schema's Player type. The analyzer
-    // must therefore NOT fold `Player & Move` to empty here.
-    expect(withSchema("{Player : Move | some (Player & Move)}").status).not.toBe("empty");
-    expect(withSchema("{Player : Move | some (Player & Move)}").status).not.toBe("unsat");
+describe("ForgeExprStaticAnalyzer — reserved schema names at binders", () => {
+  it("flags a comprehension that binds a schema type name as ill-typed", () => {
+    // Under the schema, `Player` is a type name and cannot be reused as a
+    // quantified variable. Surfaces as a clear ill-typed verdict at the binder.
+    expect(withSchema("{Player : Move | some Player}").status).toBe("ill-typed");
   });
 
-  it("still folds when the bound name does not collide with the schema", () => {
-    // `p` is fresh; `Player & Move` in the body really IS schema Player ∩ Move.
+  it("flags a comprehension that binds a schema relation name as ill-typed", () => {
+    expect(withSchema("{parent : Move | some parent}").status).toBe("ill-typed");
+  });
+
+  it("permits comprehensions that bind fresh names", () => {
+    // `p` is not a schema name → no policy violation.
+    expect(withSchema("{p : Move | some p}").status).toBe("unknown");
+    // And the body still gets folded with schema info: `some (Player & Move)`
+    // uses schema Player here (no shadowing), so this is empty.
     expect(withSchema("{p : Move | some (Player & Move)}").status).toBe("empty");
   });
 
-  it("does not use schema for shadowed relation names either", () => {
-    expect(withSchema("{parent : Move | some parent}").status).not.toBe("ill-typed");
+  it("bubbles ill-typed up through nested comprehensions", () => {
+    expect(withSchema("{x : Move | some {Player : Move | some Player}}").status)
+      .toBe("ill-typed");
   });
 
-  it("nested comprehensions track scope correctly", () => {
-    // Inner Player shadows; outer Move doesn't.
-    expect(withSchema("{x : Move | some {Player : Move | some (Player & Move)}}").status)
-      .not.toBe("empty");
+  it("flags quantifiers that bind schema names as ill-typed", () => {
+    expect(withSchema("all Player : Move | some Player").status).toBe("ill-typed");
+    expect(withSchema("some parent : Move | some parent").status).toBe("ill-typed");
   });
 
-  it("releases bindings after the comprehension body", () => {
-    // Inside the comp body, Player is bound and schema lookups must skip; the
-    // `Pawn in Player` clause is OUTSIDE the body, so Pawn and Player both
-    // resolve to schema types and the subtype tautology should still fire.
-    expect(
-      withSchema("(some {Player : Move | some Player}) or (Pawn in Player)").status
-    ).toBe("tautology");
+  it("permits quantifiers that bind fresh names", () => {
+    expect(withSchema("all p : Move | some p").status).toBe("unknown");
+  });
+
+  it("does not enforce the policy when no schema is supplied", () => {
+    // Without a schema, the analyzer has no notion of which names are reserved.
+    expect(analyzeForgeExpression("{Player : Move | some Player}").status).toBe("unknown");
   });
 });
 

--- a/test/static-analyzer.test.ts
+++ b/test/static-analyzer.test.ts
@@ -432,9 +432,15 @@ describe("ForgeExprStaticAnalyzer — schema-aware: subtype `in` tautologies", (
     expect(withSchema("Pawn in Object").status).toBe("tautology");
   });
 
-  it("uses `ni` symmetrically", () => {
-    expect(withSchema("Player ni Pawn").status).toBe("tautology");
-    expect(withSchema("Object ni Knight").status).toBe("tautology");
+  it("folds `ni` as the negation of `in`", () => {
+    // ni is non-membership (matches the evaluator's semantics). A ni B is
+    // unsat exactly when A in B is a tautology, i.e., A is a subtype of B.
+    expect(withSchema("Pawn ni Player").status).toBe("unsat");
+    expect(withSchema("Knight ni Object").status).toBe("unsat");
+    // Conversely, A ni B is not provable from a non-subtype direction —
+    // Player ni Pawn could still be vacuously true (if Player is empty), so
+    // we stay conservative.
+    expect(withSchema("Player ni Pawn").status).toBe("unknown");
   });
 
   it("does not falsely declare non-subtype in relations", () => {
@@ -531,6 +537,61 @@ describe("ForgeExprStaticAnalyzer — reserved schema names at binders", () => {
   it("does not enforce the policy when no schema is supplied", () => {
     // Without a schema, the analyzer has no notion of which names are reserved.
     expect(analyzeForgeExpression("{Player : Move | some Player}").status).toBe("unknown");
+  });
+});
+
+describe("ForgeExprStaticAnalyzer — ni is non-membership (not reverse containment)", () => {
+  it("X ni X is false (matches evaluator's !in semantics)", () => {
+    expectUnsat("Thing ni Thing");
+    expectUnsat("1 ni 1");
+  });
+
+  it("none ni singleton is true (singleton is not in empty)", () => {
+    expectTaut("1 ni none");
+    expectTaut("true ni none");
+  });
+
+  it("none ni none is false (empty is in empty)", () => {
+    expectUnsat("none ni none");
+  });
+
+  it("empty ni X is false (empty is in everything)", () => {
+    expectUnsat("(Thing - Thing) ni Thing");
+  });
+});
+
+describe("ForgeExprStaticAnalyzer — ill-typed propagates through short-circuits", () => {
+  it("OR does not mask an ill-typed branch with a true literal", () => {
+    expect(withSchema("true or (Player = parent)").status).toBe("ill-typed");
+    expect(withSchema("(Player = parent) or true").status).toBe("ill-typed");
+  });
+
+  it("AND does not mask an ill-typed branch with a false literal", () => {
+    expect(withSchema("false and (Player = parent)").status).toBe("ill-typed");
+    expect(withSchema("(Player = parent) and false").status).toBe("ill-typed");
+  });
+
+  it("IMP does not mask an ill-typed consequent under a false antecedent", () => {
+    expect(withSchema("false => (Player = parent)").status).toBe("ill-typed");
+  });
+
+  it("IMP does not mask an ill-typed antecedent under a true consequent", () => {
+    expect(withSchema("(Player = parent) => true").status).toBe("ill-typed");
+  });
+
+  it("IMP with ELSE surfaces ill-typed in either branch", () => {
+    expect(withSchema("true => true else (Player = parent)").status).toBe("ill-typed");
+    expect(withSchema("false => (Player = parent) else true").status).toBe("ill-typed");
+  });
+
+  it("compareOp same-subtree does not mask an ill-typed sub-expression", () => {
+    // (Player = parent) is ill-typed; even though `X = X` would normally fold
+    // to tautology, the inner ill-typedness wins.
+    expect(withSchema("(Player = parent) = (Player = parent)").status).toBe("ill-typed");
+  });
+
+  it("blocks surface ill-typed from any conjunct", () => {
+    expect(withSchema("{ true ; (Player = parent) ; true }").status).toBe("ill-typed");
   });
 });
 

--- a/test/static-analyzer.test.ts
+++ b/test/static-analyzer.test.ts
@@ -495,6 +495,40 @@ describe("ForgeExprStaticAnalyzer — schema-aware: arity mismatches", () => {
   });
 });
 
+describe("ForgeExprStaticAnalyzer — shadowing safety", () => {
+  it("does not use schema info for set-comp bound names that shadow types", () => {
+    // `Player` is bound by the comprehension to range over Move atoms; in the
+    // body it has NOTHING to do with the schema's Player type. The analyzer
+    // must therefore NOT fold `Player & Move` to empty here.
+    expect(withSchema("{Player : Move | some (Player & Move)}").status).not.toBe("empty");
+    expect(withSchema("{Player : Move | some (Player & Move)}").status).not.toBe("unsat");
+  });
+
+  it("still folds when the bound name does not collide with the schema", () => {
+    // `p` is fresh; `Player & Move` in the body really IS schema Player ∩ Move.
+    expect(withSchema("{p : Move | some (Player & Move)}").status).toBe("empty");
+  });
+
+  it("does not use schema for shadowed relation names either", () => {
+    expect(withSchema("{parent : Move | some parent}").status).not.toBe("ill-typed");
+  });
+
+  it("nested comprehensions track scope correctly", () => {
+    // Inner Player shadows; outer Move doesn't.
+    expect(withSchema("{x : Move | some {Player : Move | some (Player & Move)}}").status)
+      .not.toBe("empty");
+  });
+
+  it("releases bindings after the comprehension body", () => {
+    // Inside the comp body, Player is bound and schema lookups must skip; the
+    // `Pawn in Player` clause is OUTSIDE the body, so Pawn and Player both
+    // resolve to schema types and the subtype tautology should still fire.
+    expect(
+      withSchema("(some {Player : Move | some Player}) or (Pawn in Player)").status
+    ).toBe("tautology");
+  });
+});
+
 describe("ForgeExprStaticAnalyzer — conservative cases", () => {
   it("returns unknown for data-dependent expressions", () => {
     expectUnknown("Thing");

--- a/test/static-analyzer.test.ts
+++ b/test/static-analyzer.test.ts
@@ -1,0 +1,518 @@
+import { analyzeForgeExpression, IForgeSchema } from "../src";
+import { IRelation, IType } from "../src/types";
+
+function expectUnsat(expr: string) {
+  const result = analyzeForgeExpression(expr);
+  expect(result.status).toBe("unsat");
+}
+
+function expectTaut(expr: string) {
+  const result = analyzeForgeExpression(expr);
+  expect(result.status).toBe("tautology");
+}
+
+function expectUnknown(expr: string) {
+  const result = analyzeForgeExpression(expr);
+  expect(result.status).toBe("unknown");
+}
+
+function expectEmpty(expr: string) {
+  const result = analyzeForgeExpression(expr);
+  expect(result.status).toBe("empty");
+}
+
+// Minimal IForgeSchema for the tests below. Lattice:
+//   Object
+//   ├─ Player          (Pawn, Knight extend Player)
+//   ├─ Move
+//   └─ Color
+// Relations:
+//   parent : Player -> Player
+//   move   : Player -> Move
+//   color  : Object -> Color
+function makeSchema(): IForgeSchema {
+  const mkType = (id: string, lineage: string[]): IType => ({
+    id,
+    types: [id, ...lineage],
+    atoms: [],
+    isBuiltin: false,
+  });
+  const types: IType[] = [
+    mkType("Object", []),
+    mkType("Player", ["Object"]),
+    mkType("Move", ["Object"]),
+    mkType("Color", ["Object"]),
+    mkType("Pawn", ["Player", "Object"]),
+    mkType("Knight", ["Player", "Object"]),
+  ];
+  const mkRel = (name: string, cols: string[]): IRelation => ({
+    id: name,
+    name,
+    types: cols,
+    tuples: [],
+  });
+  const relations: IRelation[] = [
+    mkRel("parent", ["Player", "Player"]),
+    mkRel("move", ["Player", "Move"]),
+    mkRel("color", ["Object", "Color"]),
+  ];
+  return {
+    getTypes: () => types,
+    getRelations: () => relations,
+  };
+}
+
+function withSchema(expr: string) {
+  return analyzeForgeExpression(expr, makeSchema());
+}
+
+describe("ForgeExprStaticAnalyzer — literal folding", () => {
+  it("folds true / false constants", () => {
+    expectTaut("true");
+    expectUnsat("false");
+  });
+
+  it("folds numeric equality", () => {
+    expectUnsat("1 = 2");
+    expectTaut("1 = 1");
+    expectTaut("3 = 3");
+  });
+
+  it("folds numeric ordering", () => {
+    expectUnsat("1 < 1");
+    expectUnsat("2 < 1");
+    expectTaut("1 < 2");
+    expectTaut("1 <= 1");
+    expectTaut("2 >= 1");
+    expectUnsat("1 > 1");
+  });
+
+  it("treats `none` as the empty set", () => {
+    expectEmpty("none");
+  });
+
+  it("folds boolean equality", () => {
+    expectUnsat("true = false");
+    expectTaut("true = true");
+  });
+});
+
+describe("ForgeExprStaticAnalyzer — boolean propagation", () => {
+  it("short-circuits AND with false", () => {
+    expectUnsat("false and true");
+    expectUnsat("true and false");
+    expectUnsat("(1 < 1) and (some Thing)");
+  });
+
+  it("short-circuits OR with true", () => {
+    expectTaut("true or false");
+    expectTaut("false or true");
+    expectTaut("(1 = 1) or (some Thing)");
+  });
+
+  it("folds nested AND/OR with literals", () => {
+    expectTaut("true and true");
+    expectUnsat("false or false");
+  });
+
+  it("folds NEG over a known boolean", () => {
+    expectTaut("not false");
+    expectUnsat("not true");
+    expectTaut("!(1 = 2)");
+  });
+
+  it("folds implication", () => {
+    expectTaut("false => true");
+    expectTaut("false => false");      // vacuous
+    expectUnsat("true => false");
+    expectTaut("true => true");
+  });
+
+  it("folds IFF and XOR with literals", () => {
+    expectTaut("true iff true");
+    expectUnsat("true iff false");
+  });
+});
+
+describe("ForgeExprStaticAnalyzer — same-subtree contradictions", () => {
+  it("rejects strict ordering of the same expression", () => {
+    expectUnsat("Thing < Thing");
+    expectUnsat("foo > foo");
+  });
+
+  it("accepts equality / weak ordering of the same expression", () => {
+    expectTaut("Thing = Thing");
+    expectTaut("foo <= foo");
+    expectTaut("foo >= foo");
+  });
+
+  it("catches X and not X", () => {
+    expectUnsat("(some Thing) and (not (some Thing))");
+    expectUnsat("(not (some Thing)) and (some Thing)");
+  });
+
+  it("catches X or not X", () => {
+    expectTaut("(some Thing) or (not (some Thing))");
+  });
+
+  it("treats X - X as empty", () => {
+    expectUnsat("some (Thing - Thing)");
+    expectTaut("no (Thing - Thing)");
+    expectTaut("lone (Thing - Thing)");
+    expectUnsat("one (Thing - Thing)");
+  });
+
+  it("treats X iff X as true", () => {
+    expectTaut("(some Thing) iff (some Thing)");
+  });
+});
+
+describe("ForgeExprStaticAnalyzer — multiplicity over the empty set", () => {
+  it("flags some/one/two over none", () => {
+    expectUnsat("some none");
+    expectUnsat("one none");
+    expectUnsat("two none");
+  });
+
+  it("treats no/lone over none as true", () => {
+    expectTaut("no none");
+    expectTaut("lone none");
+  });
+
+  it("propagates emptiness through intersection", () => {
+    expectUnsat("some (none & Thing)");
+    expectUnsat("some (Thing & none)");
+    expectTaut("no (none & Thing)");
+  });
+});
+
+describe("ForgeExprStaticAnalyzer — always-empty propagation", () => {
+  it("propagates emptiness through set ops", () => {
+    expectEmpty("Thing - Thing");
+    expectEmpty("none & Thing");
+    expectEmpty("Thing & none");
+    expectEmpty("none + none");
+  });
+
+  it("propagates emptiness through dot join (either side)", () => {
+    expectEmpty("none.field");
+    expectEmpty("Thing.none");
+    expectEmpty("a.b.none");
+    expectEmpty("(none.field).other");
+  });
+
+  it("propagates emptiness through box join", () => {
+    expectEmpty("none[a]");
+    expectEmpty("f[none]");
+    expectEmpty("f[a, none, b]");
+  });
+
+  it("propagates emptiness through Cartesian product", () => {
+    expectEmpty("none -> Thing");
+    expectEmpty("Thing -> none");
+    expectEmpty("none -> none");
+  });
+
+  it("propagates emptiness through transpose and ^", () => {
+    expectEmpty("~none");
+    expectEmpty("^none");
+    expectEmpty("~(Thing - Thing)");
+    expectEmpty("^(Thing - Thing)");
+  });
+
+  it("does NOT call *none empty (it equals iden)", () => {
+    expectUnknown("*none");
+  });
+
+  it("folds #empty to 0 (not empty)", () => {
+    // #none yields the integer 0, which is neither empty nor a literal bool
+    expectUnknown("#none");
+    // But comparisons against it can still fold
+    expectTaut("#none = 0");
+    expectUnsat("#none > 0");
+    expectUnsat("#(Thing - Thing) > 0");
+  });
+
+  it("handles set comprehensions with a statically-false body", () => {
+    expectEmpty("{x : Thing | false}");
+    expectEmpty("{x : Thing | 1 = 2}");
+    expectEmpty("{x : Thing | (some y) and (not (some y))}");
+  });
+
+  it("handles set comprehensions over an empty domain", () => {
+    expectEmpty("{x : none | true}");
+    expectEmpty("{x : Thing - Thing | true}");
+  });
+});
+
+describe("ForgeExprStaticAnalyzer — disjoint intersections", () => {
+  it("catches X & (Y - X) and the symmetric case", () => {
+    expectEmpty("Thing & (Other - Thing)");
+    expectEmpty("(Other - Thing) & Thing");
+  });
+
+  it("catches X & (Y - Z - X) via the minus chain", () => {
+    expectEmpty("Thing & (A - B - Thing)");
+    expectEmpty("Thing & ((A - Thing) - B)");
+    expectEmpty("(A - B - Thing) & Thing");
+  });
+
+  it("catches X & (Y + Z - X)", () => {
+    expectEmpty("Thing & (A + B - Thing)");
+  });
+
+  it("catches distinct numeric singletons", () => {
+    expectEmpty("1 & 2");
+    expectEmpty("0 & 5");
+    // Same value stays non-empty
+    expectUnknown("1 & 1");        // sameSubtree returns the value, kind=num
+  });
+
+  it("does NOT misfire on overlapping or unrelated subtractions", () => {
+    // (Thing - Other) keeps Thing-elements, so intersection with Thing
+    // is NOT necessarily empty.
+    expectUnknown("(Thing - Other) & Thing");
+    // Different identifier on the subtrahend
+    expectUnknown("Thing & (A - Other)");
+  });
+});
+
+describe("ForgeExprStaticAnalyzer — block conjunction", () => {
+  it("folds a block with any false conjunct to unsat", () => {
+    expectUnsat("{ 1 = 2 }");
+    expectUnsat("{ true; false }");
+    expectUnsat("{ 1 = 1; 1 = 2 }");
+    expectUnsat("{ some Thing; 1 < 1 }");
+  });
+
+  it("folds a block of all literal-trues to tautology", () => {
+    expectTaut("{ true }");
+    expectTaut("{ 1 = 1; true }");
+    expectTaut("{ 1 < 2; 2 < 3; true }");
+  });
+
+  it("returns unknown when no conjunct is statically decidable", () => {
+    expectUnknown("{ some Thing; some Other }");
+  });
+});
+
+describe("ForgeExprStaticAnalyzer — quantifier folding", () => {
+  it("folds quantifiers over an empty domain", () => {
+    expectUnsat("some x : none | true");
+    expectUnsat("one x : none | true");
+    expectUnsat("two x : none | true");
+    expectTaut("all x : none | true");
+    expectTaut("no x : none | true");
+    expectTaut("lone x : none | true");
+  });
+
+  it("folds quantifiers over a derived empty domain", () => {
+    expectUnsat("some x : (Thing - Thing) | true");
+    expectTaut("all x : (Thing - Thing) | (1 = 2)");
+  });
+
+  it("folds quantifiers with a statically-false body", () => {
+    expectUnsat("some x : Thing | false");
+    expectUnsat("some x : Thing | 1 = 2");
+    expectUnsat("one x : Thing | false");
+    expectTaut("no x : Thing | false");
+    expectTaut("lone x : Thing | false");
+  });
+
+  it("folds `all x | true` regardless of domain", () => {
+    expectTaut("all x : Thing | true");
+    expectTaut("all x : Thing | 1 = 1");
+  });
+
+  it("returns unknown when nothing is decidable", () => {
+    expectUnknown("some x : Thing | some y");
+    expectUnknown("all x : Thing | some x");
+  });
+});
+
+describe("ForgeExprStaticAnalyzer — same-subtree boolean shortcuts", () => {
+  it("X and X → X", () => {
+    expectTaut("true and true");
+    expectUnknown("(some Thing) and (some Thing)");
+  });
+
+  it("X or X → X", () => {
+    expectTaut("true or true");
+    expectUnsat("false or false");
+  });
+
+  it("X xor X → false", () => {
+    expectUnsat("(some Thing) xor (some Thing)");
+    expectUnsat("true xor true");
+  });
+
+  it("X iff not X → false", () => {
+    expectUnsat("(some Thing) iff (not (some Thing))");
+    expectUnsat("(not (some Thing)) iff (some Thing)");
+  });
+});
+
+describe("ForgeExprStaticAnalyzer — MINUS subset patterns", () => {
+  it("(X & Y) - X → empty", () => {
+    expectEmpty("(Thing & Other) - Thing");
+    expectEmpty("(Other & Thing) - Thing");
+  });
+
+  it("X - (X + Y) → empty", () => {
+    expectEmpty("Thing - (Thing + Other)");
+    expectEmpty("Thing - (Other + Thing)");
+    expectEmpty("Thing - (Thing + Other + More)");
+  });
+
+  it("does NOT misfire on non-subset cases", () => {
+    expectUnknown("(Thing + Other) - Thing");   // Other might remain
+    expectUnknown("Thing - (Other - Thing)");   // depends on Other
+  });
+
+  it("folds numeric subtraction of literals", () => {
+    expectTaut("(2 - 1) = 1");
+    expectTaut("(5 - 5) = 0");
+  });
+});
+
+describe("ForgeExprStaticAnalyzer — PLUS / set union with empty", () => {
+  it("X + none → X (propagates X's analysis)", () => {
+    // none + none was already empty
+    expectEmpty("none + none");
+    // none + (X - X)  →  (X - X)  →  empty
+    expectEmpty("none + (Thing - Thing)");
+    expectEmpty("(Thing - Thing) + none");
+  });
+
+  it("folds numeric addition", () => {
+    expectTaut("(1 + 2) = 3");
+    expectUnsat("(1 + 2) = 4");
+  });
+});
+
+describe("ForgeExprStaticAnalyzer — singleton-vs-empty comparisons", () => {
+  it("singleton = none and none = singleton → false", () => {
+    expectUnsat("1 = none");
+    expectUnsat("none = 1");
+    expectUnsat("true = none");
+  });
+
+  it("singleton in none → false", () => {
+    expectUnsat("1 in none");
+    expectUnsat("true in none");
+  });
+
+  it("none ni singleton → false", () => {
+    expectUnsat("none ni 1");
+  });
+});
+
+describe("ForgeExprStaticAnalyzer — schema-aware: type disjointness", () => {
+  it("flags intersection of disjoint types as empty", () => {
+    expect(withSchema("Player & Move").status).toBe("empty");
+    expect(withSchema("Player & Color").status).toBe("empty");
+    expect(withSchema("Move & Color").status).toBe("empty");
+  });
+
+  it("does not misfire on subtype intersections", () => {
+    // Pawn ⊆ Player, so the intersection is not statically empty.
+    expect(withSchema("Pawn & Player").status).toBe("unknown");
+    expect(withSchema("Player & Pawn").status).toBe("unknown");
+  });
+
+  it("does nothing without a schema", () => {
+    expectUnknown("Player & Move");
+  });
+});
+
+describe("ForgeExprStaticAnalyzer — schema-aware: subtype `in` tautologies", () => {
+  it("folds A in B when A is a subtype of B", () => {
+    expect(withSchema("Pawn in Player").status).toBe("tautology");
+    expect(withSchema("Knight in Object").status).toBe("tautology");
+    expect(withSchema("Pawn in Object").status).toBe("tautology");
+  });
+
+  it("uses `ni` symmetrically", () => {
+    expect(withSchema("Player ni Pawn").status).toBe("tautology");
+    expect(withSchema("Object ni Knight").status).toBe("tautology");
+  });
+
+  it("does not falsely declare non-subtype in relations", () => {
+    expect(withSchema("Player in Pawn").status).toBe("unknown");
+    expect(withSchema("Player in Move").status).toBe("unknown");
+  });
+});
+
+describe("ForgeExprStaticAnalyzer — schema-aware: join column-type mismatch", () => {
+  it("flags dot join where boundary types are disjoint", () => {
+    // parent : Player -> Player; Color disjoint from Player.
+    expect(withSchema("Color.parent").status).toBe("empty");
+    expect(withSchema("Move.parent").status).toBe("empty");
+    // Color used on the right: parent ends in Player; Color is disjoint, so
+    // joining `Player.color` would actually be OK (Player <: Object, and color
+    // takes Object), so this should NOT misfire.
+  });
+
+  it("does not misfire on compatible joins", () => {
+    // Player ⊆ Object, so Player.color is fine. `typed` surfaces as unknown.
+    expect(withSchema("Player.color").status).not.toBe("empty");
+    expect(withSchema("Player.color").status).not.toBe("ill-typed");
+    // Pawn is a Player; Pawn.parent is fine (parent's first column is Player).
+    expect(withSchema("Pawn.parent").status).not.toBe("empty");
+    expect(withSchema("Pawn.parent").status).not.toBe("ill-typed");
+  });
+
+  it("flags arity-0 dot join (unary join unary)", () => {
+    expect(withSchema("Player.Move").status).toBe("ill-typed");
+  });
+});
+
+describe("ForgeExprStaticAnalyzer — schema-aware: arity mismatches", () => {
+  it("flags `=` between operands of different arity", () => {
+    expect(withSchema("Player = parent").status).toBe("ill-typed");
+    expect(withSchema("parent = Player").status).toBe("ill-typed");
+  });
+
+  it("flags `in` / `ni` between operands of different arity", () => {
+    expect(withSchema("Player in parent").status).toBe("ill-typed");
+    expect(withSchema("parent ni Player").status).toBe("ill-typed");
+  });
+
+  it("flags set ops between operands of different arity", () => {
+    expect(withSchema("Player + parent").status).toBe("ill-typed");
+    expect(withSchema("Player - parent").status).toBe("ill-typed");
+    expect(withSchema("Player & parent").status).toBe("ill-typed");
+  });
+
+  it("does not flag matching-arity ops", () => {
+    expect(withSchema("Player + Move").status).toBe("unknown");
+    expect(withSchema("parent + move").status).toBe("unknown");
+  });
+
+  it("bubbles ill-typed up through wrappers", () => {
+    expect(withSchema("not (Player = parent)").status).toBe("ill-typed");
+    expect(withSchema("some (Player + parent)").status).toBe("ill-typed");
+  });
+});
+
+describe("ForgeExprStaticAnalyzer — conservative cases", () => {
+  it("returns unknown for data-dependent expressions", () => {
+    expectUnknown("Thing");
+    expectUnknown("some Thing");
+    expectUnknown("Thing.field");
+    expectUnknown("Thing = Other");        // different identifiers
+    expectUnknown("#Thing > 0");
+  });
+
+  it("returns unknown for data-dependent quantifiers", () => {
+    expectUnknown("all x : Thing | some x");
+    // `some x : Thing | true` *would* be tautology if we knew Thing is
+    // non-empty, but we can't tell statically — so unknown is correct.
+    expectUnknown("some x : Thing | true");
+  });
+
+  it("returns unknown when a parse error occurs", () => {
+    expectUnknown("(((");
+    expectUnknown("");
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new `ForgeExprStaticAnalyzer` that classifies an expression as `unsat | tautology | empty | ill-typed | unknown` purely by walking the parse tree — no instance data required. When an optional `IForgeSchema` is supplied, the analyzer also uses the type lattice (subtype lineage) and relation declarations to catch type-disjoint intersections, subtype `in` tautologies, join column-type mismatches, and arity errors.

Kept deliberately separate from `evaluateExpression`; wiring as an eval-time short-circuit is tracked as a follow-up issue.

## What gets caught

**Data-free**
- Literal folding (`1=2`, `1<1`, `none`, `true and false`, set comprehensions with statically-false bodies, etc.)
- Boolean propagation through AND/OR/IMP/IFF/XOR/NEG
- Same-subtree contradictions: `X and not X`, `X < X`, `X iff not X`, `X - X`, `X & (Y - X)`, `1 & 2`, ...
- Empty-set propagation through dot/box joins, `~`, `^`, `->`, `&`, `+`, set-comprehension domains
- Block conjunction folding; quantifier folding for empty domains and static-false bodies
- `X + none → X`, `#empty → 0`

**Schema-aware** (language-agnostic — only assumes subtype lineage and arity, not Forge-specific `extends`-disjointness)
- Type disjointness in `&` and `=` (`Player & Move` → empty)
- Subtype tautologies in `in` / `ni` (`Pawn in Player` → tautology)
- Dot-join column-type mismatch (`Color.parent` → empty when `parent : Player → Player`)
- Arity mismatches in `=`, `in`, `ni`, `+`, `-`, `&` → new `ill-typed` status
- `ill-typed` bubbles up through wrappers (`not (Player = parent)` → ill-typed)

**Soundness note**: closed-world disjointness — A and B are disjoint iff no type in the supplied lattice has both in its lineage. Sound only when the schema is treated as complete; documented on `analyzeForgeExpression`.

## Public API

```ts
analyzeForgeExpression(expr: string, schema?: IForgeSchema): StaticAnalysis

type StaticAnalysis =
  | { status: "unsat";     reason: string }
  | { status: "tautology"; reason: string }
  | { status: "empty";     reason: string }
  | { status: "ill-typed"; reason: string }
  | { status: "unknown" };
```

`IForgeSchema` is a subset of the existing `IDataInstance` (just `getTypes()` + `getRelations()`), so any data instance can also be passed as a schema.

## Test plan

- [x] 72 new tests in `test/static-analyzer.test.ts` covering every category above
- [x] Full existing suite still green (182 tests across 12 suites)
- [x] `tsc --noEmit` clean
- [ ] Reviewer: scan the closed-world disjointness rule in `SchemaInfo.areDisjoint` to confirm the assumption matches expected usage

## Follow-ups

Tracked separately:
- Wire analyzer output into `evaluateExpression` as a short-circuit (issue linked in PR)
- Multi-step type inference for `r.s.t` joins
- Functional-field shortcuts (`lone a.field` when field is declared `one`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)