### PR TITLE
Reuse inner ForgeExprEvaluator across evaluateExpression calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-graph-query",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "TypeScript evaluator for Forge expressions with browser-compatible UMD bundle",
   "main": "dist/simple-graph-query.bundle.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,8 +25,37 @@ function createForgeParser(input: string): ForgeParser {
   return parser;
 }
 
+/**
+ * Evaluates Forge expressions against an `IDataInstance`.
+ *
+ * ## Caching contract (important for correctness)
+ *
+ * For performance, this class caches an inner evaluator (with its relation
+ * index and subexpression cache) across `evaluateExpression` calls. The
+ * cache is invalidated when the `datum` field is reassigned to a different
+ * reference, but **not** when the underlying `IDataInstance` is mutated in
+ * place (e.g. adding/removing atoms or tuples on the same object).
+ *
+ * If you mutate the underlying data in place, you **must** call
+ * {@link invalidate} (or reassign `datum` to a new object) before the next
+ * `evaluateExpression` call. Otherwise queries may return stale results.
+ *
+ * Recommended patterns:
+ *  - Treat `IDataInstance` as immutable; create a new instance on data
+ *    changes and construct a new `SimpleGraphQueryEvaluator` (or assign to
+ *    `.datum`).
+ *  - Or, if you mutate in place, call `invalidate()` after each mutation
+ *    batch.
+ */
 export class SimpleGraphQueryEvaluator {
 
+  /**
+   * The data instance evaluated against. Reassigning this field is a
+   * supported invalidation signal — the inner evaluator cache is rebuilt
+   * on the next `evaluateExpression` call. **In-place mutation of the
+   * existing object is NOT detected**; call {@link invalidate} in that
+   * case.
+   */
   datum: IDataInstance;
   forgeListener : ForgeListenerImpl = new ForgeListenerImpl();
   walker : ParseTreeWalker = new ParseTreeWalker();
@@ -35,14 +64,28 @@ export class SimpleGraphQueryEvaluator {
 
   // Cached inner evaluator. Reused across evaluateExpression calls so its
   // relation cache / relation index / subexpression cache survive between
-  // calls. Invalidated when the `datum` reference changes — consumers that
-  // mutate the underlying data are expected to construct a new
-  // SimpleGraphQueryEvaluator (or reassign `this.datum`) to signal that.
+  // calls. Invalidated when the `datum` reference changes, or explicitly
+  // via `invalidate()`. NOT invalidated by in-place mutation of the
+  // underlying IDataInstance -- callers must signal that themselves.
   private cachedEvaluator: ForgeExprEvaluator | null = null;
   private cachedEvaluatorDatum: IDataInstance | null = null;
 
   constructor(datum: IDataInstance) {
     this.datum = datum;
+  }
+
+  /**
+   * Discard the cached inner evaluator (and its relation index /
+   * subexpression cache). Call this after mutating the underlying
+   * `IDataInstance` in place, so the next `evaluateExpression` sees the
+   * updated data.
+   *
+   * Cheap: just nulls a couple of references. The caches rebuild lazily
+   * on the next query.
+   */
+  invalidate(): void {
+    this.cachedEvaluator = null;
+    this.cachedEvaluatorDatum = null;
   }
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,14 @@ export class SimpleGraphQueryEvaluator {
   // Cache for parsed expressions to avoid re-parsing the same expression
   private parseTreeCache: Map<string, ExprContext> = new Map();
 
+  // Cached inner evaluator. Reused across evaluateExpression calls so its
+  // relation cache / relation index / subexpression cache survive between
+  // calls. Invalidated when the `datum` reference changes — consumers that
+  // mutate the underlying data are expected to construct a new
+  // SimpleGraphQueryEvaluator (or reassign `this.datum`) to signal that.
+  private cachedEvaluator: ForgeExprEvaluator | null = null;
+  private cachedEvaluatorDatum: IDataInstance | null = null;
+
   constructor(datum: IDataInstance) {
     this.datum = datum;
   }
@@ -41,7 +49,7 @@ export class SimpleGraphQueryEvaluator {
   getExpressionParseTree(forgeExpr: string) {
     const parser = createForgeParser(forgeExpr);
     const tree = parser.parseExpr();
-    
+
     // TODO: Is this wrong?
     if (!tree || tree.childCount === 0) {
       throw new Error(`Parse error in ${forgeExpr}`);
@@ -74,7 +82,14 @@ export class SimpleGraphQueryEvaluator {
       }
     }
 
-    const evaluator = new ForgeExprEvaluator(this.datum);
+    // Reuse the inner evaluator across calls. Rebuild only when the datum
+    // reference has changed (the contract: callers signal "data changed"
+    // by swapping the datum reference, not by mutating it in place).
+    if (this.cachedEvaluator === null || this.cachedEvaluatorDatum !== this.datum) {
+      this.cachedEvaluator = new ForgeExprEvaluator(this.datum);
+      this.cachedEvaluatorDatum = this.datum;
+    }
+    const evaluator = this.cachedEvaluator;
 
     try {
 
@@ -83,6 +98,14 @@ export class SimpleGraphQueryEvaluator {
       // ensure we're visiting an ExprContext
       return result;
     } catch (error) {
+      // The visit threw mid-traversal, so the evaluator's transient state
+      // (environment stack) may be inconsistent. Discard the cached
+      // evaluator so the next call rebuilds from a clean slate. The
+      // relation cache will be rebuilt lazily on first use, which is the
+      // same as the pre-change behavior.
+      this.cachedEvaluator = null;
+      this.cachedEvaluatorDatum = null;
+
       if (error instanceof NameNotFoundError) {
         // Return an empty EvalResult for undefined names
         let emptyResult: EvalResult = [];

--- a/test/cache-invalidation.test.ts
+++ b/test/cache-invalidation.test.ts
@@ -1,0 +1,99 @@
+import { SimpleGraphQueryEvaluator } from "../src";
+import { IDataInstance, IAtom, IRelation, ITuple, IType } from "../src/types";
+import { Tuple, areTupleArraysEqual } from "../src/ForgeExprEvaluator";
+
+// Minimal mutable IDataInstance for testing in-place mutation behavior.
+class MutableInstance implements IDataInstance {
+  constructor(
+    private types: IType[],
+    private relations: IRelation[],
+    private atoms: IAtom[],
+  ) {}
+  getTypes() { return this.types; }
+  getRelations() { return this.relations; }
+  getAtoms() { return this.atoms; }
+  getAtomType(id: string): IType {
+    for (const t of this.types) {
+      if (t.atoms.some(a => a.id === id)) return t;
+    }
+    throw new Error(`atom ${id} not found`);
+  }
+
+  // Mutate a relation's tuples in place.
+  setRelationTuples(name: string, tuples: ITuple[]): void {
+    const rel = this.relations.find(r => r.name === name);
+    if (!rel) throw new Error(`relation ${name} not found`);
+    rel.tuples = tuples;
+  }
+}
+
+function makeInstance(edges: [string, string][]): MutableInstance {
+  const atomIds = Array.from(new Set(edges.flat()));
+  const atoms: IAtom[] = atomIds.map(id => ({ id, type: "Node", label: id }));
+  const nodeType: IType = {
+    id: "Node",
+    types: ["Node"],
+    atoms,
+    isBuiltin: false,
+  };
+  const edgeTuples: ITuple[] = edges.map(([a, b]) => ({
+    atoms: [a, b],
+    types: ["Node", "Node"],
+  }));
+  const edgeRelation: IRelation = {
+    id: "edge",
+    name: "edge",
+    types: ["Node", "Node"],
+    tuples: edgeTuples,
+  };
+  return new MutableInstance([nodeType], [edgeRelation], atoms);
+}
+
+function asTuples(result: unknown): Tuple[] {
+  return Array.isArray(result) ? (result as Tuple[]) : [];
+}
+
+describe("Cache invalidation contract", () => {
+  it("invalidate() picks up in-place mutations of the datum", () => {
+    const datum = makeInstance([["a", "b"]]);
+    const evalUtil = new SimpleGraphQueryEvaluator(datum);
+
+    // Prime the cache.
+    const before = evalUtil.evaluateExpression("edge");
+    expect(areTupleArraysEqual(asTuples(before), [["a", "b"]])).toBe(true);
+
+    // Mutate the datum in place.
+    datum.setRelationTuples("edge", [
+      { atoms: ["a", "b"], types: ["Node", "Node"] },
+      { atoms: ["b", "c"], types: ["Node", "Node"] },
+    ]);
+
+    // Without invalidation, the cached result reflects the old data.
+    // (This is documented in the JSDoc for SimpleGraphQueryEvaluator.)
+    const stale = evalUtil.evaluateExpression("edge");
+    expect(areTupleArraysEqual(asTuples(stale), [["a", "b"]])).toBe(true);
+
+    // After invalidate(), the next evaluation picks up the new tuples.
+    evalUtil.invalidate();
+    const fresh = evalUtil.evaluateExpression("edge");
+    expect(
+      areTupleArraysEqual(asTuples(fresh), [
+        ["a", "b"],
+        ["b", "c"],
+      ])
+    ).toBe(true);
+  });
+
+  it("reassigning datum to a new reference invalidates implicitly", () => {
+    const a = makeInstance([["a", "b"]]);
+    const b = makeInstance([["x", "y"]]);
+    const evalUtil = new SimpleGraphQueryEvaluator(a);
+
+    const first = evalUtil.evaluateExpression("edge");
+    expect(areTupleArraysEqual(asTuples(first), [["a", "b"]])).toBe(true);
+
+    evalUtil.datum = b;
+    const second = evalUtil.evaluateExpression("edge");
+    expect(areTupleArraysEqual(asTuples(second), [["x", "y"]])).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Cache the inner `ForgeExprEvaluator` inside `SimpleGraphQueryEvaluator` and reuse it across `evaluateExpression` calls. The previous code did `new ForgeExprEvaluator(this.datum)` on every call, which threw away the relation cache, relation index, and subexpression cache between calls — the very caches PERFORMANCE.md describes as the big wins.
- Invalidate via reference check: rebuild the inner evaluator only when `this.datum` is a different reference. The sole consumer (spytial-core) already signals data changes by constructing a new `SimpleGraphQueryEvaluator` via `SGraphQueryEvaluator.initialize`, so this matches the existing invalidation contract.
- Discard the cached evaluator on any thrown exception during `visit` to avoid carrying potentially inconsistent transient state (`environmentStack`) across calls. The next call rebuilds from a clean slate — same behavior as before for the error path.
- Bump minor version 2.6.0 → 2.7.0.

## Why
spytial-core's `enforceConstraintsAndRegenerate` flow runs N selector queries per layout pass between `initialize()` calls. Before this change, each of those N queries paid the full relation-cache + index build cost. After this change, the cost is paid once per `initialize()` and amortized across all N queries.

## Test plan
- [x] `npx jest` — 200/200 tests pass locally
- [x] `npx tsc --noEmit` — clean
- [x] `performance.test.ts` ran ~10% faster (2.37s vs 2.63s) in an isolated run — small but real
- [ ] Verify in spytial-core that nothing depends on the inner evaluator being fresh per call
- [ ] Measure end-to-end layout-pass timing in spytial-core to quantify the real win

🤖 Generated with [Claude Code](https://claude.com/claude-code)