### PR TITLE
Make divide[] real division; add floor[] and ceil[]

### DIFF
--- a/.claude/skills.md
+++ b/.claude/skills.md
@@ -103,10 +103,12 @@ true, false    // boolean literals
 add[a, b]         // integer addition
 subtract[a, b]    // integer subtraction  
 multiply[a, b]    // integer multiplication
-divide[a, b]      // integer division (floor)
+divide[a, b]      // real (floating-point) division
 remainder[a, b]   // modulo
 abs[x]            // absolute value
 sign[x]           // returns -1, 0, or 1
+floor[x]          // round down to the nearest integer
+ceil[x]           // round up to the nearest integer
 min[Set]          // minimum value in set
 max[Set]          // maximum value in set
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-graph-query",
-  "version": "2.7.2",
+  "version": "2.8.0",
   "description": "TypeScript evaluator for Forge expressions with browser-compatible UMD bundle",
   "main": "dist/simple-graph-query.bundle.js",
   "types": "dist/index.d.ts",

--- a/src/ForgeExprEvaluator.ts
+++ b/src/ForgeExprEvaluator.ts
@@ -233,7 +233,7 @@ function bitwidthWraparound(value: number, bitwidth: number): number {
 // list as we support more
 
 const SUPPORTED_BINARY_BUILTINS = ["add", "subtract", "multiply", "divide", "remainder"];
-const SUPPORTED_UNARY_BUILTINS: string[] = ["abs", "sign"];
+const SUPPORTED_UNARY_BUILTINS: string[] = ["abs", "sign", "floor", "ceil"];
 const SUPPORTED_SET_BUILTINS: string[] = ["min", "max"];
 
 export const SUPPORTED_BUILTINS = SUPPORTED_BINARY_BUILTINS.concat(
@@ -2259,7 +2259,7 @@ export class ForgeExprEvaluator
         result = arg1 * arg2;
         break;
       case "divide":
-        result = Math.floor(arg1 / arg2); // Integer division
+        result = arg1 / arg2; // Real (floating-point) division
         break;
       case "remainder":
         result = arg1 % arg2;
@@ -2277,20 +2277,19 @@ export class ForgeExprEvaluator
 
 
 
-    if (!isSingleValue(args) || !isNumber(args)) {
+    const v = extractNumber(args);
+    if (v === undefined) {
       throw new Error(`Expected 1 argument for ${operation} that evaluates to a number.`);
     }
 
-    let v = args;
-
     // Possible unary operations:
-    //abs[]: returns the absolute value of value
-    //sign[]: returns 1 if value is > 0, 0 if value is 0, and -1 if value is < 0
+    //abs[]:   returns the absolute value of value
+    //sign[]:  returns 1 if value is > 0, 0 if value is 0, and -1 if value is < 0
+    //floor[]: rounds value down to the nearest integer
+    //ceil[]:  rounds value up to the nearest integer
 
     if (operation === "abs") {
-      let res = Math.abs(v);
-      // Now adjust to the bitwidth
-      return res;
+      return Math.abs(v);
     }
     else if (operation === "sign") {
       if (v > 0) {
@@ -2300,6 +2299,12 @@ export class ForgeExprEvaluator
       } else {
         return 0;
       }
+    }
+    else if (operation === "floor") {
+      return Math.floor(v);
+    }
+    else if (operation === "ceil") {
+      return Math.ceil(v);
     } else {
       throw new Error(`Unsupported operation: ${operation}`);
     }

--- a/test/type-inference.test.ts
+++ b/test/type-inference.test.ts
@@ -162,4 +162,29 @@ describe("@: operator with string-first approach", () => {
     const result2 = evaluatorUtil.evaluateExpression('multiply[@num:(0.5), @num:(4.0)]');
     expect(result2).toBe(2);
   });
+
+  it("divide performs real (floating-point) division", () => {
+    const datum = new TTTDataInstance();
+    const evaluatorUtil = new SimpleGraphQueryEvaluator(datum);
+
+    // Previously floored to an integer; now returns the exact quotient.
+    expect(evaluatorUtil.evaluateExpression('divide[7, 2]')).toBe(3.5);
+    expect(evaluatorUtil.evaluateExpression('divide[1, 4]')).toBe(0.25);
+    // Evenly-divisible operands are unaffected.
+    expect(evaluatorUtil.evaluateExpression('divide[6, 3]')).toBe(2);
+  });
+
+  it("supports floor and ceil", () => {
+    const datum = new TTTDataInstance();
+    const evaluatorUtil = new SimpleGraphQueryEvaluator(datum);
+
+    expect(evaluatorUtil.evaluateExpression('floor[@num:(3.7)]')).toBe(3);
+    expect(evaluatorUtil.evaluateExpression('ceil[@num:(3.2)]')).toBe(4);
+    // Integers pass through unchanged.
+    expect(evaluatorUtil.evaluateExpression('floor[6]')).toBe(6);
+    expect(evaluatorUtil.evaluateExpression('ceil[6]')).toBe(6);
+    // floor/ceil compose with real division.
+    expect(evaluatorUtil.evaluateExpression('floor[divide[7, 2]]')).toBe(3);
+    expect(evaluatorUtil.evaluateExpression('ceil[divide[7, 2]]')).toBe(4);
+  });
 });


### PR DESCRIPTION
## Summary

Reworks integer-only division into real division and adds the two `Number → Int` conversion builtins.

- **`divide[a, b]` is now real division** — returns the exact quotient `a / b` instead of `Math.floor(a / b)`. So `divide[7, 2]` is now `3.5`, not `3`.
- **New `floor[x]` and `ceil[x]` unary builtins.** Integer (floor) division is now spelled `floor[divide[a, b]]`.
- The unary builtin handler now accepts `[[n]]` singleton tuples as well as raw numbers (via the existing `extractNumber` helper), matching how the binary builtins already coerce their operands.
- Docs (`.claude/skills.md`) and tests updated.

Dispatch is by membership in `SUPPORTED_*_BUILTINS`, and `SUPPORTED_BUILTINS` is re-derived from those arrays, so the free-variable finder picks up `floor`/`ceil` automatically — no other wiring needed.

## ⚠️ Behavior change

`divide` previously floored. Any query relying on that now gets a fraction. The drop-in replacement for the old behavior is `floor[divide[a, b]]`.

Versioned as a **minor** bump (`2.7.2` → `2.8.0`), treating `floor`/`ceil` as the headline additive feature. Note downstream `spytial-core` depends on `^2.7.2`, so it will pick up the new `divide` semantics on its next install — worth a heads-up there.

## Testing

- `npx jest` — 208 passed (14 suites), including new cases for real division and `floor`/`ceil` (integer identity + composition with `divide`).
- `npx tsc --noEmit` — clean.

## Note

`package-lock.json` was already out of sync with `package.json` (stuck at `2.2.1`), so following the existing convention I bumped only `package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)