### PR TITLE
Implement sum aggregator (sum x: S | intExpr)

### DIFF
--- a/.claude/skills.md
+++ b/.claude/skills.md
@@ -40,6 +40,9 @@ lone x: Set | expr     // at most one
 one x: Set | expr      // exactly one
 two x: Set | expr      // exactly two
 
+// Aggregator (returns a number, not a boolean)
+sum x: Set | intExpr   // sums intExpr over every binding of x
+
 // Multiple variables
 all x, y: Set | expr
 all disj x, y: Set | expr   // x and y must be different
@@ -130,7 +133,6 @@ These Forge/Alloy features are **not available**:
 | Let bindings | `let x = e \| body` | Not implemented |
 | Override | `R ++ S` | Not implemented |
 | Type restriction | `S <: R`, `R :> S` | Not implemented |
-| Sum expression | `sum x: S \| intExpr` | Not implemented |
 | Temporal operators | `always`, `eventually`, `after`, `until`, etc. | Requires trace semantics |
 | Primed expressions | `expr'` | Requires state model |
 | Backquoted atoms | `` `AtomName `` | Not implemented |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-graph-query",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "TypeScript evaluator for Forge expressions with browser-compatible UMD bundle",
   "main": "dist/simple-graph-query.bundle.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-graph-query",
-  "version": "2.9.0",
+  "version": "2.8.1",
   "description": "TypeScript evaluator for Forge expressions with browser-compatible UMD bundle",
   "main": "dist/simple-graph-query.bundle.js",
   "types": "dist/index.d.ts",

--- a/src/ForgeExprEvaluator.ts
+++ b/src/ForgeExprEvaluator.ts
@@ -707,6 +707,51 @@ export class ForgeExprEvaluator
         quantifiedSets.push(varQuantifiedSets[varName]);
       }
       
+      // `sum <decls> | <intExpr>`: accumulate the numeric body over every
+      // binding of the quantified variables. Unlike the boolean quantifiers
+      // below, the body evaluates to a number, so this needs its own loop --
+      // and it must not use the boolean numeric-comparison optimization, which
+      // skips body evaluation entirely.
+      if (ctx.quant()!.SUM_TOK()) {
+        const sumCombinations = getCombinations(quantifiedSets);
+        const sumEnv: Environment = { env: {}, type: "quantDecl" };
+        this.environmentStack.push(sumEnv);
+
+        let total = 0;
+        for (const tuple of sumCombinations) {
+          if (isDisjoint) {
+            const seen = new Set();
+            let tupleDisjoint = true;
+            for (const val of tuple) {
+              if (seen.has(val)) {
+                tupleDisjoint = false;
+                break;
+              }
+              seen.add(val);
+            }
+            if (!tupleDisjoint) {
+              continue;
+            }
+          }
+          for (let j = 0; j < varNames.length; j++) {
+            sumEnv.env[varNames[j]] = tuple[j];
+          }
+          const bodyValue = this.visit(barExpr);
+          const bodyNumber = extractNumber(bodyValue);
+          if (bodyNumber === undefined) {
+            this.environmentStack.pop();
+            throw new Error(
+              "Expected the expression after the bar in a `sum` to evaluate to a number!"
+            );
+          }
+          total += bodyNumber;
+        }
+
+        this.environmentStack.pop();
+        this.cacheResult(ctx, freeVarsKey, total);
+        return total;
+      }
+
       // Try to optimize numeric comparisons
       let product: Tuple[];
       let useOptimizedPath = false;
@@ -856,7 +901,8 @@ export class ForgeExprEvaluator
           return value;
         }
       }
-      // TODO: don't have support for SUM_TOK yet
+      // NOTE: SUM_TOK is handled above (it returns a number, not a boolean),
+      // before this boolean-quantifier result logic.
     }
 
     // TODO: fix this!

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -614,5 +614,39 @@ describe("sgq-evaluator ", () => {
     const result = evaluatorUtil.evaluateExpression(expr);
     expect(result).toBe(true);
   });
-  
+
+  // Int in this fixture is the bitwidth-4 range {-8 .. 7}.
+  it("sum aggregates a numeric body over the full quantified set", () => {
+    const datum = new TTTDataInstance();
+    const evaluatorUtil = new SimpleGraphQueryEvaluator(datum);
+
+    // -8 + -7 + ... + 6 + 7  ==  -8
+    expect(evaluatorUtil.evaluateExpression("sum i: Int | @num:i")).toBe(-8);
+  });
+
+  it("sum aggregates over a comprehension subset", () => {
+    const datum = new TTTDataInstance();
+    const evaluatorUtil = new SimpleGraphQueryEvaluator(datum);
+
+    // 1 + 2 + ... + 7  ==  28
+    expect(evaluatorUtil.evaluateExpression("sum i: {x: Int | x > 0} | @num:i")).toBe(28);
+    // Body is a real int expression, evaluated per binding: 2 * 28 == 56
+    expect(evaluatorUtil.evaluateExpression("sum i: {x: Int | x > 0} | multiply[@num:i, 2]")).toBe(56);
+  });
+
+  it("sum over an empty set is 0", () => {
+    const datum = new TTTDataInstance();
+    const evaluatorUtil = new SimpleGraphQueryEvaluator(datum);
+
+    expect(evaluatorUtil.evaluateExpression("sum i: {x: Int | x > 100} | @num:i")).toBe(0);
+  });
+
+  it("sum ranges over the cartesian product of multiple variables", () => {
+    const datum = new TTTDataInstance();
+    const evaluatorUtil = new SimpleGraphQueryEvaluator(datum);
+
+    // For i, j in {1..7}: sum of (i + j) == 2 * |S| * sum(S) == 2 * 7 * 28 == 392
+    expect(evaluatorUtil.evaluateExpression("sum i, j: {x: Int | x > 0} | add[@num:i, @num:j]")).toBe(392);
+  });
+
 });


### PR DESCRIPTION
## Summary

`sum` was reserved in the grammar (`SUM_TOK` in the `quant` rule) but never implemented — the quantifier path in `visitExpr` literally had `// TODO: don't have support for SUM_TOK yet`. This wires it up.

`sum <decls> | <intExpr>` binds the quantified variables over the cartesian product of their sets and accumulates the numeric body:

```forge
sum i: Int | @num:i                          // -8   (bitwidth-4 Int, -8..7)
sum i: {x: Int | x > 0} | @num:i             // 28   (1 + 2 + ... + 7)
sum i: {x: Int | x > 0} | multiply[@num:i, 2] // 56  (real int expr per binding)
sum i, j: {x: Int | x > 0} | add[@num:i, @num:j] // 392 (cartesian)
```

## Implementation notes

- Handled as its own branch in the quantifier evaluation, **separate from the boolean quantifiers** (`all`/`no`/`some`/`lone`/`one`). The body of `sum` is a number, not a boolean, so it needs a dedicated loop — and it must bypass the boolean numeric-comparison optimization (`useOptimizedPath`), which skips body evaluation entirely and would break the accumulation.
- Uses the existing `extractNumber` helper, so the body may be a raw number or a `[[n]]` singleton.
- Supports `disj` decls, evaluates an empty binding set to `0`, and ranges over the cartesian product for multiple variables.
- Errors if the body doesn't evaluate to a number.
- Replaced the stale `// TODO: SUM_TOK` with a pointer comment; documented `sum` in `.claude/skills.md` and removed it from the unsupported-features list.

## Testing

- `npx jest` — 212 passed (14 suites), including 4 new `sum` cases (full-range identity, comprehension subset, non-trivial body, empty→0, multi-variable cartesian). Boolean quantifiers unaffected.
- `npx tsc --noEmit` — clean.

## Version

Patch bump `2.8.0` → `2.8.1` (`package.json` only, matching the repo's existing convention where the lockfile isn't bumped). Release is still tag-triggered (`publish.yml`), so this won't publish on merge.