### PR TITLE
Treat scalars as singleton sets in `in`/`ni` (Alloy/Forge semantics)

### DIFF
--- a/.claude/skills.md
+++ b/.claude/skills.md
@@ -69,12 +69,14 @@ A -> B         // cartesian product
 ```forge
 A = B          // set equality
 A in B         // subset (A ⊆ B)
-A ni B         // superset (A ⊇ B)
+A ni B         // non-membership: !(A in B)
 x < y          // numeric less than
 x > y          // numeric greater than
 x <= y         // less than or equal (also: =<)
 x >= y         // greater than or equal
 ```
+A scalar is treated as a singleton set, so `in` is uniformly subset:
+`a in b` for two scalars is equality, `a in (b + c + ...)` is membership.
 
 ### Multiplicity Expressions
 ```forge

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-graph-query",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "description": "TypeScript evaluator for Forge expressions with browser-compatible UMD bundle",
   "main": "dist/simple-graph-query.bundle.js",
   "types": "dist/index.d.ts",

--- a/src/ForgeExprEvaluator.ts
+++ b/src/ForgeExprEvaluator.ts
@@ -1293,24 +1293,21 @@ export class ForgeExprEvaluator
           break;
         case "in":
         case "ni": {
-          let membershipResult: boolean;
-          // this should be true if the left value is equal to the right value,
-          // or a subset of it
-          if (isTupleArray(leftChildValue) && isTupleArray(rightChildValue)) {
-            if (areTupleArraysEqual(leftChildValue, rightChildValue)) {
-              membershipResult = true;
-            } else {
-              // check if left is subset of right
-              membershipResult = isTupleArraySubset(leftChildValue, rightChildValue);
-            }
-          } else if (isTupleArray(rightChildValue)) {
-            membershipResult = rightChildValue.some(
-              (tuple) => tuple.length === 1 && tuple[0] === leftChildValue
-            );
-          } else {
-            // left is a tuple array but right is a single value, so false
-            membershipResult = false;
-          }
+          // In Alloy/Forge everything is a relation, and a scalar is just a
+          // singleton set. Lift any scalar operand to a singleton tuple so `in`
+          // is uniformly subset:
+          //   a in b     ({a} ⊆ {b})  -> equality when both are scalars
+          //   a in {..}  ({a} ⊆ set)  -> membership
+          //   {..} in b  (set ⊆ {b})  -> subset of a singleton
+          // isTupleArraySubset already returns true for equal sets and for an
+          // empty left-hand set, so a single subset check covers every case.
+          const leftSet: Tuple[] = isSingleValue(leftChildValue)
+            ? [[leftChildValue]]
+            : leftChildValue;
+          const rightSet: Tuple[] = isSingleValue(rightChildValue)
+            ? [[rightChildValue]]
+            : rightChildValue;
+          const membershipResult = isTupleArraySubset(leftSet, rightSet);
           results = ctx.compareOp()?.text === "ni" ? !membershipResult : membershipResult;
           break;
         }

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -304,6 +304,31 @@ describe("sgq-evaluator ", () => {
     expect(quantifierTwoResult).toBe(true);
   });
 
+  it("treats a scalar as a singleton set for `in`/`ni` (Alloy/Forge subset semantics)", () => {
+    const datum = new TTTDataInstance();
+    const ev = new SimpleGraphQueryEvaluator(datum);
+
+    // Scalar `in` scalar is equality: a singleton is a subset of a singleton
+    // iff the elements are equal. This path previously always returned false.
+    expect(ev.evaluateExpression("1 in 1")).toBe(true);
+    expect(ev.evaluateExpression("1 in 2")).toBe(false);
+    expect(ev.evaluateExpression("@:(X0) in red")).toBe(true); // label "red" == "red"
+    expect(ev.evaluateExpression("@:(X0) in blue")).toBe(false);
+
+    // `ni` is the negation, so for scalars it now reads as inequality.
+    expect(ev.evaluateExpression("1 ni 1")).toBe(false);
+    expect(ev.evaluateExpression("1 ni 2")).toBe(true);
+
+    // Membership against a real (multi-element) set is unchanged...
+    expect(ev.evaluateExpression("@:(X0) in (red + blue)")).toBe(true);
+    expect(ev.evaluateExpression("@:(X0) not in (red + blue)")).toBe(false);
+
+    // ...and `in` with a single value now behaves, so the old "use = for one
+    // value" footgun is gone: this comprehension keeps only the red player.
+    const reds = ev.evaluateExpression("{p: Player | @:p in red}");
+    expect(areEquivalentTupleArrays(reds, [["X0"]])).toBe(true);
+  });
+
   it("can evaluate implies with else", () => {
     const datum = new TTTDataInstance();
     const evaluatorUtil = new SimpleGraphQueryEvaluator(datum);


### PR DESCRIPTION
## What

`in`/`ni` now lift any scalar operand to a singleton tuple and do one uniform subset check, matching Alloy/Forge (where everything is a relation and a scalar *is* a singleton set):

| expression | before | after |
|---|---|---|
| `a in b` (two scalars) | always `false` | equality (`{a} ⊆ {b}`) |
| `a in (b + c)` | membership | membership (unchanged) |
| `{..} in b` (set in scalar) | always `false` | subset of a singleton |

`ni` polarity is untouched — it stays `!(a in b)`.

## Why

Scalar-vs-scalar `in` always returned `false` (and `not in` always `true`). That's a footgun: refactoring `@:(x.color) = red` into `@:(x.color) in red` silently returned nothing, and `not in red` silently returned everything. Now `in` is correct for one value as well as a set.

This also removes a latent inconsistency: `ForgeExprStaticAnalyzer` already folds `1 in 1` → `true` (via `sameSubtree`), while the evaluator returned `false`. They now agree.

## Also

- Fixes a doc error in `.claude/skills.md`: `ni` was labeled "superset (A ⊇ B)" but is actually non-membership `!(A in B)` — corrected, with a note that scalars are singleton sets.

## Tests

- New regression test in `test/basic.test.ts` covering scalar equality, `ni` negation, membership, and the comprehension footgun.
- Full suite: **213 pass** (was 212). `tsc --noEmit` clean.

## Version

Patch bump 2.8.1 → 2.8.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)