### PR TITLE
Treat `none` and bare scalars as relations (set semantics)

### DIFF
--- a/src/ForgeExprEvaluator.ts
+++ b/src/ForgeExprEvaluator.ts
@@ -1345,20 +1345,36 @@ export class ForgeExprEvaluator
     if (ctx.SET_TOK()) {
       return childrenResults;
     }
-    if (ctx.ONE_TOK()) {
-      return isTupleArray(childrenResults) && childrenResults.length === 1;
-    }
-    if (ctx.TWO_TOK()) {
-      return isTupleArray(childrenResults) && childrenResults.length === 2;
-    }
-    if (ctx.NO_TOK()) {
-      return isTupleArray(childrenResults) && childrenResults.length === 0;
-    }
-    if (ctx.SOME_TOK()) {
-      return isTupleArray(childrenResults) && childrenResults.length > 0;
-    }
-    if (ctx.LONE_TOK()) {
-      return isTupleArray(childrenResults) && childrenResults.length <= 1;
+    // For the multiplicity checks, a bare scalar (atom or int) is a singleton
+    // set of size 1. A boolean is not a set, so it gets size -1 and every
+    // multiplicity below is false (matching the previous behavior).
+    if (
+      ctx.ONE_TOK() ||
+      ctx.TWO_TOK() ||
+      ctx.NO_TOK() ||
+      ctx.SOME_TOK() ||
+      ctx.LONE_TOK()
+    ) {
+      const setSize = isTupleArray(childrenResults)
+        ? childrenResults.length
+        : isString(childrenResults) || isNumber(childrenResults)
+          ? 1
+          : -1;
+      if (ctx.ONE_TOK()) {
+        return setSize === 1;
+      }
+      if (ctx.TWO_TOK()) {
+        return setSize === 2;
+      }
+      if (ctx.NO_TOK()) {
+        return setSize === 0;
+      }
+      if (ctx.SOME_TOK()) {
+        return setSize > 0;
+      }
+      if (ctx.LONE_TOK()) {
+        return setSize === 0 || setSize === 1;
+      }
     }
 
     return childrenResults;
@@ -1373,6 +1389,10 @@ export class ForgeExprEvaluator
 
       // should only work if arities are the same
       if (isSingleValue(leftChildValue) && isSingleValue(rightChildValue)) {
+        // Union has set semantics: two equal scalars collapse to one element.
+        if (leftChildValue === rightChildValue) {
+          return [[leftChildValue]];
+        }
         return [[leftChildValue], [rightChildValue]];
       } else if (isSingleValue(leftChildValue) && isTupleArray(rightChildValue)) {
         if (rightChildValue.length === 0) {
@@ -1462,10 +1482,15 @@ export class ForgeExprEvaluator
     //console.log('childrenResults in expr9:', childrenResults);
 
     if (ctx.CARD_TOK()) {
-      if (!isTupleArray(childrenResults)) {
-        throw new Error("The cardinal operator must be applied to a set of tuples!");
+      if (isTupleArray(childrenResults)) {
+        return childrenResults.length;
       }
-      return childrenResults.length;
+      // A scalar atom or int is a singleton set (cardinality 1). Booleans are
+      // formulas, not sets, so they remain an error.
+      if (isString(childrenResults) || isNumber(childrenResults)) {
+        return 1;
+      }
+      throw new Error("The cardinal operator must be applied to a set of tuples!");
     }
 
     return childrenResults;
@@ -1877,6 +1902,14 @@ export class ForgeExprEvaluator
         //   throw new Error(`Constant ${value} is outside the bitwidth of ${this.bitwidth}!`);
         // }
         return value;
+      }
+      // Handle none (the empty relation). Without this, `none` falls through to
+      // the string-literal branch below and evaluates to the string "none",
+      // which then pollutes every set operation it touches (e.g.
+      // `S + none` gains a spurious `["none"]` element and `#none` throws).
+      // The static analyzer already treats `none` as the empty set.
+      if (constant.NONE_TOK() !== undefined) {
+        return [];
       }
       // Handle iden (identity relation)
       if (constant.IDEN_TOK() !== undefined) {

--- a/test/set-semantics.test.ts
+++ b/test/set-semantics.test.ts
@@ -1,0 +1,77 @@
+import { EvaluationResult, SimpleGraphQueryEvaluator } from "../src";
+import { Tuple, areTupleArraysEqual } from "../src/ForgeExprEvaluator";
+import { RBTTDataInstance } from "./testdatainstances";
+
+// A relation/set result is a Tuple[]; compare as sets of tuples.
+function sameSet(result: EvaluationResult, expected: Tuple[]) {
+  if (Array.isArray(result)) {
+    return areTupleArraysEqual(result as Tuple[], expected);
+  }
+  return false;
+}
+
+function ev(expr: string): EvaluationResult {
+  return new SimpleGraphQueryEvaluator(new RBTTDataInstance()).evaluateExpression(expr);
+}
+
+describe("scalars and `none` as relations (Alloy/Forge set semantics)", () => {
+  // ---- Fix 1: `none` is the empty relation, not the string "none" ----
+  describe("`none` constant", () => {
+    it("evaluates to the empty set", () => {
+      expect(sameSet(ev("none"), [])).toBe(true);
+    });
+
+    it("is empty under multiplicity checks", () => {
+      expect(ev("no none")).toBe(true);
+      expect(ev("some none")).toBe(false);
+    });
+
+    it("has cardinality 0", () => {
+      expect(ev("#none")).toBe(0);
+    });
+
+    it("is a union/difference identity and does not leak a `none` element", () => {
+      // RBTreeNode + none == RBTreeNode
+      const base = ev("RBTreeNode");
+      expect(sameSet(ev("RBTreeNode + none"), base as Tuple[])).toBe(true);
+      // no spurious ["none"] atom sneaks in
+      expect(sameSet(ev("RBTreeNode & none"), [])).toBe(true);
+      expect(sameSet(ev("none + none"), [])).toBe(true);
+    });
+  });
+
+  // ---- Fix 2: a bare scalar is a singleton set ----
+  describe("cardinality and multiplicity on scalars", () => {
+    it("counts a scalar as a singleton", () => {
+      expect(ev("#5")).toBe(1);
+      expect(ev("#(add[1, 2])")).toBe(1);
+    });
+
+    it("treats a scalar as `some`/`one`/`lone`", () => {
+      expect(ev("some 5")).toBe(true);
+      expect(ev("one 5")).toBe(true);
+      expect(ev("lone 5")).toBe(true);
+      expect(ev("no 5")).toBe(false);
+      expect(ev("two 5")).toBe(false);
+    });
+
+    it("works on scalars produced by arithmetic builtins", () => {
+      expect(ev("some (add[2, 3])")).toBe(true);
+      expect(ev("one (subtract[10, 4])")).toBe(true);
+    });
+  });
+
+  // ---- Fix 3: union of equal scalars dedups ----
+  describe("union of equal scalars", () => {
+    it("collapses to a single element", () => {
+      expect(sameSet(ev("1 + 1"), [[1]])).toBe(true);
+      expect(ev("#(1 + 1)")).toBe(1);
+      expect(sameSet(ev("add[1, 1] + add[1, 1]"), [[2]])).toBe(true);
+    });
+
+    it("still unions distinct scalars", () => {
+      expect(sameSet(ev("1 + 2"), [[1], [2]])).toBe(true);
+      expect(ev("#(1 + 2)")).toBe(2);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Three evaluator fixes in `src/ForgeExprEvaluator.ts`, all rooted in the Alloy/Forge principle that *everything is a relation* — `none` is the empty set and a scalar is a singleton set. This is the same class of gap that #60 closed for `in`/`ni`; a few operators were still missing it.

## The bugs

### 1. `none` was unimplemented → leaked the string `"none"` into results (high impact)

`none` is a grammar constant (`const: NONE_TOK | UNIV_TOK | IDEN_TOK | MINUS_TOK? number`), and the static analyzer already treats it as the empty set. But `visitExpr18` handled `iden`, `univ`, numbers, and `true`/`false` and **never** `NONE_TOK`, so `none` fell through to `return \`${constant.text}\`` and became the **string** `"none"`.

| Expression | Before | After |
|---|---|---|
| `none` | `"none"` | `[]` |
| `RBTreeNode + none` | `[…, ["n0"], ["none"]]` — spurious atom | `RBTreeNode` |
| `#none` | **throws** | `0` |
| `no none` | `false` | `true` |

### 2. `#` and multiplicity (`some`/`one`/`lone`/`no`/`two`) rejected bare scalars

`visitExpr9` (`#`) and `visitExpr7` required `isTupleArray` and bailed on a `SingleValue`, but a scalar atom/int is a singleton set.

| Expression | Before | After |
|---|---|---|
| `#5` | **throws** | `1` |
| `some (add[2, 3])` | `false` | `true` |
| `one 5` / `lone 5` | `false` | `true` |

Booleans are still not sets (they error / return `false`), so no valid path regresses.

### 3. Union `+` of two equal scalars did not dedup

The scalar+scalar branch of `visitExpr8` returned `[[left],[right]]` unconditionally, while every other union branch dedups.

| Expression | Before | After |
|---|---|---|
| `1 + 1` | `[[1],[1]]` | `[[1]]` |
| `#(1 + 1)` | `2` | `1` |

## Tests

- New `test/set-semantics.test.ts` — 9 cases covering all three fixes (`none` as empty set, cardinality/multiplicity on scalars, union dedup).
- None of these paths were previously exercised by the suite.
- Full suite: **222 passed** (213 prior + 9 new); `tsc --noEmit` clean.

## Notes

- No version bump — leaving that to the maintainer's release flow (recent fix PRs #57/#58/#60 didn't bump inline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)