### PR TITLE
Fix `all` under numeric optimizer + transpose of empty relation

### DIFF
--- a/src/ForgeExprEvaluator.ts
+++ b/src/ForgeExprEvaluator.ts
@@ -752,11 +752,20 @@ export class ForgeExprEvaluator
         return total;
       }
 
-      // Try to optimize numeric comparisons
+      // Try to optimize numeric comparisons.
+      //
+      // The optimizer generates ONLY the bindings that satisfy the comparison
+      // and marks each as true (skipping body evaluation). That is sound for
+      // quantifiers whose result depends on the *satisfying* bindings --
+      // `some`/`no`/`one`/`two`/`lone` (which count them) -- but NOT for `all`,
+      // whose result depends on the existence of a *falsifying* binding. If we
+      // discard the falsifying bindings, `all` never sees a counterexample and
+      // returns `!foundFalse === true` unconditionally. So exclude `all`.
       let product: Tuple[];
       let useOptimizedPath = false;
-      
-      if (!isDisjoint && varNames.length >= 2 && areAllNumericSets(quantifiedSets)) {
+
+      const isAllQuantifier = ctx.quant()!.ALL_TOK() !== undefined;
+      if (!isDisjoint && !isAllQuantifier && varNames.length >= 2 && areAllNumericSets(quantifiedSets)) {
         // Try to detect and optimize numeric comparison patterns
         const pattern = detectNumericComparisonPattern(barExpr, varNames);
         if (pattern && pattern.type !== 'none') {
@@ -1802,8 +1811,16 @@ export class ForgeExprEvaluator
     if (ctx.TILDE_TOK()) {
       // this flips the order of the elements in the tuples of a relation if
       // the relation has arity 2
-      if (isTupleArray(childrenResults) && childrenResults.length > 0 && childrenResults[0].length === 2) {
-        return childrenResults.map((tuple) => [tuple[1], tuple[0]]);
+      if (isTupleArray(childrenResults)) {
+        // The transpose of the empty relation is the empty relation. Guarding
+        // only on `length > 0` made `~<empty>` throw (e.g. `~(left - left)`),
+        // even though `^`/`*` handle the empty relation fine.
+        if (childrenResults.length === 0) {
+          return [];
+        }
+        if (childrenResults[0].length === 2) {
+          return childrenResults.map((tuple) => [tuple[1], tuple[0]]);
+        }
       }
       throw new Error("expected the expression provided to ~ to have arity 2; bad arity received!");
     }

--- a/test/quantifier-optimizer.test.ts
+++ b/test/quantifier-optimizer.test.ts
@@ -1,0 +1,70 @@
+import { EvaluationResult, SimpleGraphQueryEvaluator } from "../src";
+import { Tuple, areTupleArraysEqual } from "../src/ForgeExprEvaluator";
+import { RBTTDataInstance } from "./testdatainstances";
+
+function ev(expr: string): EvaluationResult {
+  return new SimpleGraphQueryEvaluator(new RBTTDataInstance()).evaluateExpression(expr);
+}
+
+function sameSet(result: EvaluationResult, expected: Tuple[]) {
+  return Array.isArray(result) && areTupleArraysEqual(result as Tuple[], expected);
+}
+
+describe("numeric-comparison optimizer must not break `all`", () => {
+  // The optimizer generates only the *satisfying* bindings of a comparison and
+  // skips body evaluation. That is unsound for `all`, whose truth depends on the
+  // existence of a *falsifying* binding. Over the set {1,2} every comparison
+  // below has at least one violating ordered pair, so each `all` is false.
+  it("all a,b: {1,2} | a <= b  => false (pair (2,1) violates)", () => {
+    expect(ev("all a, b : (1 + 2) | a <= b")).toBe(false);
+  });
+  it("all a,b: {1,2} | a < b   => false", () => {
+    expect(ev("all a, b : (1 + 2) | a < b")).toBe(false);
+  });
+  it("all a,b: {1,2} | a > b   => false", () => {
+    expect(ev("all a, b : (1 + 2) | a > b")).toBe(false);
+  });
+  it("all a,b: {1,2} | a >= b  => false", () => {
+    expect(ev("all a, b : (1 + 2) | a >= b")).toBe(false);
+  });
+  it("all a,b: {1,2} | a != b  => false (reflexive pairs violate)", () => {
+    expect(ev("all a, b : (1 + 2) | a != b")).toBe(false);
+  });
+
+  it("still returns true when every binding genuinely satisfies", () => {
+    // Singleton {5}: the only pair is (5,5), and 5 <= 5 holds.
+    expect(ev("all a, b : (5) | a <= b")).toBe(true);
+  });
+
+  it("does not regress the sound quantifiers (they count satisfying bindings)", () => {
+    expect(ev("some a, b : (1 + 2) | a < b")).toBe(true);
+    expect(ev("no a, b : (1 + 2) | a < b")).toBe(false);
+    expect(ev("one a, b : (1 + 2) | a < b")).toBe(true); // only (1,2)
+    expect(ev("some a, b : (1 + 2) | a > b")).toBe(true); // (2,1)
+  });
+
+  it("optimized set comprehensions are unaffected (they collect satisfying tuples)", () => {
+    expect(sameSet(ev("{ a, b : (1 + 2) | a < b }"), [[1, 2]])).toBe(true);
+  });
+});
+
+describe("transpose (~) of an empty relation", () => {
+  it("returns the empty relation instead of throwing", () => {
+    // (left - left) is an empty arity-2 relation.
+    expect(sameSet(ev("~(left - left)"), [])).toBe(true);
+  });
+
+  it("still transposes a non-empty binary relation", () => {
+    // left contains (n0, n3); the transpose must contain (n3, n0).
+    const result = ev("~left");
+    expect(Array.isArray(result)).toBe(true);
+    const tuples = result as Tuple[];
+    expect(tuples.some((t) => t[0] === "n3" && t[1] === "n0")).toBe(true);
+  });
+
+  it("still rejects a non-empty relation whose arity is not 2", () => {
+    // RBTreeNode is a unary set; ~ of it is an arity error.
+    const result = ev("~RBTreeNode");
+    expect((result as any)?.error).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Two independent evaluator correctness bugs in `src/ForgeExprEvaluator.ts`, both returning a wrong answer (or erroring) on a valid relational query. Found while auditing the numeric-comparison optimizer, which silently skips body evaluation.

## Bug 1 — `all` over a numeric comparison silently returns `true` (high impact)

The numeric-comparison optimizer (`NumericConstraintOptimizer`) generates **only the bindings that satisfy** the comparison and marks each `true`, skipping body evaluation. That's sound for the quantifiers whose result depends on the *satisfying* bindings — `some`/`no`/`one`/`two`/`lone` (which count them) and set comprehensions (which collect them) — but **not** for `all`, whose result depends on the existence of a *falsifying* binding. With the falsifying bindings thrown away, `foundFalse` is never set and `all` returns `!foundFalse === true` unconditionally.

Over the set `{1, 2}`:

| Expression | Before | Correct |
|---|---|---|
| `all a, b : (1 + 2) \| a <= b` | `true` | `false` (pair `(2,1)`) |
| `all a, b : (1 + 2) \| a < b` | `true` | `false` |
| `all a, b : (1 + 2) \| a != b` | `true` | `false` (reflexive pairs) |
| `all a, b : (1 + 2) \| a >= b` | `true` | `false` |

Affected every pattern the optimizer detects (`<`, `>`, `<=`, `>=`, `!=`, `not a = b`) over a non-disjoint, all-numeric quantification with ≥ 2 variables. `all disj …` was already safe (disjoint quantifications skip the optimizer).

**Fix:** exclude `all` from the optimized path. It falls back to the standard cartesian product + per-binding evaluation — which already short-circuits on the first violating pair (`ALL_TOK && foundFalse → return false`), so there's no meaningful performance cost. `some`/`no`/`one`/`two`/`lone` and set comprehensions keep the optimization.

## Bug 2 — `~` (transpose) of an empty relation throws

The transpose guard required `childrenResults.length > 0`, so transposing an empty binary relation threw `"expected the expression provided to ~ to have arity 2"` instead of returning the empty relation — even though `^` and `*` handle the empty relation fine.

| Expression | Before | Correct |
|---|---|---|
| `~(left - left)` | **throws** | `[]` |

**Fix:** return `[]` for an empty relation; keep the arity-2 check (and its error) for non-empty relations.

## Tests

- New `test/quantifier-optimizer.test.ts` — 11 cases: the five broken `all` patterns, a genuinely-true `all` (regression guard), the sound quantifiers + comprehension (no regression), and transpose of empty / non-empty / wrong-arity relations.
- Full suite: **224 passed** (213 prior + 11 new); `tsc --noEmit` clean.

## Notes

- Independent of #61; no overlapping files beyond both touching the evaluator. No version bump (left to the release flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)