### PR TITLE
Evaluator Fixes

### DIFF
--- a/.claude/skills.md
+++ b/.claude/skills.md
@@ -59,6 +59,9 @@ A & B          // intersection
 A.B            // relational join (last column of A joins first column of B)
 A[B]           // box join (equivalent to B.A)
 A -> B         // cartesian product
+R ++ S         // override: S, plus R's tuples starting outside S's domain
+S <: R         // domain restriction: R's tuples that start in S
+R :> S         // range restriction: R's tuples that end in S
 ^R             // transitive closure
 *R             // reflexive transitive closure
 ~R             // transpose/inverse
@@ -69,7 +72,7 @@ A -> B         // cartesian product
 ```forge
 A = B          // set equality
 A in B         // subset (A ⊆ B)
-A ni B         // non-membership: !(A in B)
+A ni B         // reverse containment: B in A
 x < y          // numeric less than
 x > y          // numeric greater than
 x <= y         // less than or equal (also: =<)
@@ -99,6 +102,7 @@ two expr       // true if |expr| = 2
 none           // empty set
 univ           // all atoms in the instance
 iden           // identity relation {(a,a) | a in univ}
+`Atom0         // atom literal: the atom with that id
 Int            // integer type
 true, false    // boolean literals
 ```
@@ -116,6 +120,7 @@ floor[x]          // round down to the nearest integer
 ceil[x]           // round up to the nearest integer
 min[Set]          // minimum value in set
 max[Set]          // maximum value in set
+sum[Set]          // sum of values in set (0 for the empty set)
 ```
 
 ### Label Access (Custom Extension)
@@ -133,11 +138,9 @@ These Forge/Alloy features are **not available**:
 | Feature | Syntax | Reason |
 |---------|--------|--------|
 | Let bindings | `let x = e \| body` | Not implemented |
-| Override | `R ++ S` | Not implemented |
-| Type restriction | `S <: R`, `R :> S` | Not implemented |
 | Temporal operators | `always`, `eventually`, `after`, `until`, etc. | Requires trace semantics |
 | Primed expressions | `expr'` | Requires state model |
-| Backquoted atoms | `` `AtomName `` | Not implemented |
+| Arrow multiplicities | `A one -> lone B` | Declaration/constraint syntax, no value as an expression |
 
 ## Code Examples
 

--- a/src/ForgeExprEvaluator.ts
+++ b/src/ForgeExprEvaluator.ts
@@ -1787,9 +1787,25 @@ export class ForgeExprEvaluator
       if (ctx.expr10() === undefined || ctx.expr11() === undefined) {
         throw new Error("Expected the pplus operator to have 2 operands of the right type!");
       }
-      const leftChildValue = this.visit(ctx.expr10()!);
-      const rightChildValue = this.visit(ctx.expr11()!);
-      throw new Error("**NOT IMPLEMENTING FOR NOW** pplus (`++`)");
+      const original = asTupleArray(this.visit(ctx.expr10()!));
+      const replacement = asTupleArray(this.visit(ctx.expr11()!));
+
+      // should only work if arities are the same
+      if (
+        original.length > 0 &&
+        replacement.length > 0 &&
+        original[0].length !== replacement[0].length
+      ) {
+        throw new Error("arity mismatch in relational override!");
+      }
+
+      // `p ++ q` overrides by first atom: wherever q has a tuple, every tuple
+      // of p starting at the same atom goes, rather than the two merging.
+      const overridden = new Set(replacement.map((tuple) => tuple[0]));
+      return deduplicateConcat([
+        original.filter((tuple) => !overridden.has(tuple[0])),
+        replacement,
+      ]);
     }
 
     return this.visitChildren(ctx);

--- a/src/ForgeExprEvaluator.ts
+++ b/src/ForgeExprEvaluator.ts
@@ -70,6 +70,12 @@ function isTupleArray(value: EvalResult): value is Tuple[] {
   return Array.isArray(value);
 }
 
+// In Alloy/Forge a scalar is a singleton set, so every relational operator
+// takes one after this lifting.
+function asTupleArray(value: EvalResult): Tuple[] {
+  return isSingleValue(value) ? [[value]] : value;
+}
+
 function isBoolean(value: EvalResult): value is boolean {
   return typeof value === "boolean";
 }
@@ -710,8 +716,8 @@ export class ForgeExprEvaluator
 
   // Optimized dotJoin that can use pre-built relation indexes
   private dotJoin(left: EvalResult, right: EvalResult, rightRelationName?: string): EvalResult {
-    const leftExpr = isSingleValue(left) ? [[left]] : left;
-    const rightExpr = isSingleValue(right) ? [[right]] : right;
+    const leftExpr = asTupleArray(left);
+    const rightExpr = asTupleArray(right);
 
     // Try to use pre-built index if available
     let rightIndex: Map<SingleValue, Tuple[]> | undefined;
@@ -1567,12 +1573,8 @@ export class ForgeExprEvaluator
           //   {..} in b  (set ⊆ {b})  -> subset of a singleton
           // isTupleArraySubset already returns true for equal sets and for an
           // empty left-hand set, so a single subset check covers every case.
-          const leftSet: Tuple[] = isSingleValue(leftChildValue)
-            ? [[leftChildValue]]
-            : leftChildValue;
-          const rightSet: Tuple[] = isSingleValue(rightChildValue)
-            ? [[rightChildValue]]
-            : rightChildValue;
+          const leftSet = asTupleArray(leftChildValue);
+          const rightSet = asTupleArray(rightChildValue);
           // `a ni b` is reverse containment -- it means `b in a`, NOT `a not in b`.
           const [subset, superset] =
             ctx.compareOp()?.text === "ni" ? [rightSet, leftSet] : [leftSet, rightSet];
@@ -1877,13 +1879,8 @@ export class ForgeExprEvaluator
       const leftChildValue = this.visit(ctx.expr12()!);
       const rightChildValue = this.visit(ctx.expr13()!);
 
-      // Ensure both values are tuple arrays
-      const leftTuples = isSingleValue(leftChildValue) ? [[leftChildValue]] : leftChildValue;
-      const rightTuples = isSingleValue(rightChildValue) ? [[rightChildValue]] : rightChildValue;
-
-      if (!isTupleArray(leftTuples) || !isTupleArray(rightTuples)) {
-        throw new Error("Arrow operator operands must be tuple arrays or single values");
-      }
+      const leftTuples = asTupleArray(leftChildValue);
+      const rightTuples = asTupleArray(rightChildValue);
 
       // Compute the Cartesian product
       const result: Tuple[] = [];
@@ -1902,27 +1899,36 @@ export class ForgeExprEvaluator
 
   visitExpr13(ctx: Expr13Context): EvalResult {
     //console.log('visiting expr13:', ctx.text);
-    let results: EvalResult = [];
 
-    if (ctx.SUPT_TOK()) {
+    // Domain restriction `S <: r` keeps the tuples of r that start in S; range
+    // restriction `r :> S` keeps the ones that end in S. The set is always on
+    // the side the colon faces.
+    const restrictsDomain = ctx.SUBT_TOK() !== undefined;
+    if (restrictsDomain || ctx.SUPT_TOK()) {
       if (ctx.expr13() === undefined || ctx.expr14() === undefined) {
         throw new Error(
-          "Expected the supertype operator to have 2 operands of the right type!"
+          "Expected the restriction operator to have 2 operands of the right type!"
         );
       }
       const leftChildValue = this.visit(ctx.expr13()!);
       const rightChildValue = this.visit(ctx.expr14()!);
-      throw new Error("**NOT IMPLEMENTING FOR NOW** Supertype Operator (`:>`)");
-    }
-    if (ctx.SUBT_TOK()) {
-      if (ctx.expr13() === undefined || ctx.expr14() === undefined) {
+      const [restrictor, relation] = restrictsDomain
+        ? [leftChildValue, rightChildValue]
+        : [rightChildValue, leftChildValue];
+
+      const restrictorTuples = asTupleArray(restrictor);
+      const wrongArity = restrictorTuples.find((tuple) => tuple.length !== 1);
+      if (wrongArity !== undefined) {
         throw new Error(
-          "Expected the subtype operator to have 2 operands of the right type!"
+          `The ${restrictsDomain ? "<:" : ":>"} operator restricts by a set of arity 1, ` +
+          `but its ${restrictsDomain ? "left" : "right"} operand has arity ${wrongArity.length}`
         );
       }
-      const leftChildValue = this.visit(ctx.expr13()!);
-      const rightChildValue = this.visit(ctx.expr14()!);
-      throw new Error("**NOT IMPLEMENTING FOR NOW** Subtype Operator (`<:`)");
+
+      const restrictTo = new Set(restrictorTuples.map((tuple) => tuple[0]));
+      return asTupleArray(relation).filter((tuple) =>
+        restrictTo.has(restrictsDomain ? tuple[0] : tuple[tuple.length - 1])
+      );
     }
 
     return this.visitChildren(ctx);

--- a/src/ForgeExprEvaluator.ts
+++ b/src/ForgeExprEvaluator.ts
@@ -311,7 +311,7 @@ function bitwidthWraparound(value: number, bitwidth: number): number {
 
 const SUPPORTED_BINARY_BUILTINS = ["add", "subtract", "multiply", "divide", "remainder"];
 const SUPPORTED_UNARY_BUILTINS: string[] = ["abs", "sign", "floor", "ceil"];
-const SUPPORTED_SET_BUILTINS: string[] = ["min", "max"];
+const SUPPORTED_SET_BUILTINS: string[] = ["min", "max", "sum"];
 
 export const SUPPORTED_BUILTINS = SUPPORTED_BINARY_BUILTINS.concat(
   SUPPORTED_UNARY_BUILTINS,
@@ -2524,6 +2524,13 @@ export class ForgeExprEvaluator
     // of the qualName nonterminal
     //console.log('visiting qualName:', ctx.text);
 
+    // `sum` has its own token, so unlike the other builtins it never reaches
+    // visitName -- without this, `sum[e]` box-joins a relation named `sum`,
+    // which no instance has, and quietly yields the empty set.
+    if (ctx.SUM_TOK()) {
+      return "sum";
+    }
+
 
     //// SP: Commented out this optimization for now///
     // if (ctx.INT_TOK()) {
@@ -2677,7 +2684,7 @@ export class ForgeExprEvaluator
     operation: typeof SUPPORTED_SET_BUILTINS[number],
     args: EvalResult
   ): number {
-    // min and max operate on a set of integers and return the min/max value
+    // min, max and sum operate on a set of integers and return a single value.
     // The argument should be a set (tuple array of arity 1) of numbers
 
     let numbers: number[] = [];
@@ -2695,11 +2702,17 @@ export class ForgeExprEvaluator
     } else {
       throw new Error(`Expected a set of numbers for ${operation}`);
     }
-    
+
+    // The empty sum is 0. min and max of an empty set have no value at all,
+    // so they still refuse it.
+    if (operation === "sum") {
+      return numbers.reduce((total, value) => total + value, 0);
+    }
+
     if (numbers.length === 0) {
       throw new Error(`${operation} requires a non-empty set`);
     }
-    
+
     if (operation === "min") {
       return Math.min(...numbers);
     } else if (operation === "max") {

--- a/src/ForgeExprEvaluator.ts
+++ b/src/ForgeExprEvaluator.ts
@@ -1537,6 +1537,9 @@ export class ForgeExprEvaluator
 
 
           break;
+        // `=<` is the same token as `<=` (see LEQ_TOK), but the switch is on
+        // source text, so both spellings need an arm.
+        case "=<":
         case "<=":
           if (leftNum === undefined || rightNum === undefined) {
             throw new Error(

--- a/src/ForgeExprEvaluator.ts
+++ b/src/ForgeExprEvaluator.ts
@@ -714,6 +714,19 @@ export class ForgeExprEvaluator
     throw new Error(`Cannot convert ${value} to boolean`);
   }
 
+  // The value an atom denotes. Ids are strings, but an atom whose id spells a
+  // number or a boolean IS that number or boolean -- otherwise `1` and `true`
+  // would come back as "1" and "true" and compare against nothing.
+  private atomValue(id: string): SingleValue {
+    if (this.isConvertibleToNumber(id)) {
+      return Number(id);
+    }
+    if (this.isConvertibleToBoolean(id)) {
+      return this.convertToBoolean(id);
+    }
+    return id;
+  }
+
   // Optimized dotJoin that can use pre-built relation indexes
   private dotJoin(left: EvalResult, right: EvalResult, rightRelationName?: string): EvalResult {
     const leftExpr = asTupleArray(left);
@@ -794,17 +807,8 @@ export class ForgeExprEvaluator
           return;
         }
         seenAtomIds.add(atom.id);
-        
-        let value: SingleValue = atom.id;
-        // do some type conversions so we don't return a string if the value
-        // is a number or boolean
-        if (!isNaN(Number(value))) { // check if it's a number
-          value = Number(value);
-        } else if (value == "true" || value === "#t") {
-          value = true;
-        } else if (value == "false" || value === "#f") {
-          value = false;
-        }
+
+        const value = this.atomValue(atom.id);
         result.push([value, value]);
       });
     }
@@ -2212,18 +2216,12 @@ export class ForgeExprEvaluator
         // The identity relation contains tuples (x, x) for every atom x in the universe
         const atoms = this.instanceData.getAtoms();
         const idenRelation: Tuple[] = [];
-        
+
         for (const atom of atoms) {
-          let atomValue: SingleValue = atom.id;
-          // Convert numeric and boolean strings to their actual types
-          if (this.isConvertibleToNumber(atomValue)) {
-            atomValue = Number(atomValue);
-          } else if (this.isConvertibleToBoolean(atomValue)) {
-            atomValue = this.convertToBoolean(atomValue);
-          }
-          idenRelation.push([atomValue, atomValue]);
+          const value = this.atomValue(atom.id);
+          idenRelation.push([value, value]);
         }
-        
+
         return idenRelation;
       }
       // Handle univ (universal relation - all atoms)
@@ -2231,18 +2229,11 @@ export class ForgeExprEvaluator
         // The universal relation contains all atoms as unary tuples
         const atoms = this.instanceData.getAtoms();
         const univRelation: Tuple[] = [];
-        
+
         for (const atom of atoms) {
-          let atomValue: SingleValue = atom.id;
-          // Convert numeric and boolean strings to their actual types
-          if (this.isConvertibleToNumber(atomValue)) {
-            atomValue = Number(atomValue);
-          } else if (this.isConvertibleToBoolean(atomValue)) {
-            atomValue = this.convertToBoolean(atomValue);
-          }
-          univRelation.push([atomValue]);
+          univRelation.push([this.atomValue(atom.id)]);
         }
-        
+
         return univRelation;
       }
       // A double-quoted string literal. This is the ONLY way to write a string,
@@ -2267,11 +2258,15 @@ export class ForgeExprEvaluator
       throw new Error("`@` operator is Alloy specific; it is not supported by Forge!");
     }
     if (ctx.BACKQUOTE_TOK()) {
-      const name = this.visitChildren(ctx);
-      results.push(["**UNIMPLEMENTED** Backquoted Name (`` `x` ``)"]);
-
-      // TODO: implement this using name and then return the result
-      return results;
+      // An atom literal: `` `Board0 `` is that one atom of the instance, never
+      // the type or relation that happens to share the name.
+      const atomName = getIdentifierName(ctx.name()!);
+      const atom = this.instanceData.getAtoms().find((a) => a.id === atomName);
+      if (atom === undefined) {
+        this.reportUnresolvedName(atomName);
+        return [];
+      }
+      return [[this.atomValue(atom.id)]];
     }
     if (ctx.THIS_TOK()) {
       throw new Error("`this` is Alloy specific; it is not supported by Forge!");

--- a/src/ForgeExprEvaluator.ts
+++ b/src/ForgeExprEvaluator.ts
@@ -1573,8 +1573,10 @@ export class ForgeExprEvaluator
           const rightSet: Tuple[] = isSingleValue(rightChildValue)
             ? [[rightChildValue]]
             : rightChildValue;
-          const membershipResult = isTupleArraySubset(leftSet, rightSet);
-          results = ctx.compareOp()?.text === "ni" ? !membershipResult : membershipResult;
+          // `a ni b` is reverse containment -- it means `b in a`, NOT `a not in b`.
+          const [subset, superset] =
+            ctx.compareOp()?.text === "ni" ? [rightSet, leftSet] : [leftSet, rightSet];
+          results = isTupleArraySubset(subset, superset);
           break;
         }
         case "is":

--- a/src/ForgeExprEvaluator.ts
+++ b/src/ForgeExprEvaluator.ts
@@ -2654,32 +2654,43 @@ export class ForgeExprEvaluator
     }
   }
 
+  // Resolve one element of a set-builtin argument to a number. An integer can
+  // reach here as a string -- atom ids are strings, and `@:` projects a label,
+  // so `@:(x.value)` yields "12" rather than 12 -- so a string that names a
+  // number is one, following the same convention as the `univ` branch.
+  private setOperandAsNumber(
+    operation: typeof SUPPORTED_SET_BUILTINS[number],
+    value: SingleValue
+  ): number {
+    if (isNumber(value)) {
+      return value;
+    }
+    if (isString(value) && this.isConvertibleToNumber(value)) {
+      return Number(value);
+    }
+    throw new Error(
+      `${operation} expects all elements to be numbers, got: ${JSON.stringify(value)}`
+    );
+  }
+
   private evaluateSetOperation(
     operation: typeof SUPPORTED_SET_BUILTINS[number],
     args: EvalResult
   ): number {
     // min and max operate on a set of integers and return the min/max value
     // The argument should be a set (tuple array of arity 1) of numbers
-    
+
     let numbers: number[] = [];
-    
+
     if (isSingleValue(args)) {
-      if (isNumber(args)) {
-        numbers = [args];
-      } else {
-        throw new Error(`Expected a set of numbers for ${operation}`);
-      }
+      numbers = [this.setOperandAsNumber(operation, args)];
     } else if (isTupleArray(args)) {
       // Extract numbers from the tuple array
       for (const tuple of args) {
         if (tuple.length !== 1) {
           throw new Error(`${operation} expects a set of arity 1 (single column)`);
         }
-        const value = tuple[0];
-        if (!isNumber(value)) {
-          throw new Error(`${operation} expects all elements to be numbers, got: ${typeof value}`);
-        }
-        numbers.push(value);
+        numbers.push(this.setOperandAsNumber(operation, tuple[0]));
       }
     } else {
       throw new Error(`Expected a set of numbers for ${operation}`);

--- a/src/ForgeExprEvaluator.ts
+++ b/src/ForgeExprEvaluator.ts
@@ -1863,6 +1863,17 @@ export class ForgeExprEvaluator
       if (ctx.expr12() === undefined || ctx.expr13() === undefined) {
         throw new Error("Expected the arrow operator to have 2 operands of the right type!");
       }
+      // `A one -> lone B` constrains a field declaration; as an expression it
+      // denotes nothing beyond the cross product, so evaluating it as one would
+      // silently discard what the author wrote.
+      const arrowOp = ctx.arrowOp()!;
+      if (arrowOp.mult().length > 0 || arrowOp.SET_TOK().length > 0) {
+        throw new Error(
+          `Cannot evaluate the multiplicity annotations in '${arrowOp.text}': ` +
+          "they are declaration and constraint syntax, not part of an expression. " +
+          "Write a plain '->' for the cross product."
+        );
+      }
       const leftChildValue = this.visit(ctx.expr12()!);
       const rightChildValue = this.visit(ctx.expr13()!);
 

--- a/src/ForgeExprStaticAnalyzer.ts
+++ b/src/ForgeExprStaticAnalyzer.ts
@@ -564,7 +564,9 @@ export class ForgeExprStaticAnalyzer
     const bail = ForgeExprStaticAnalyzer.bailIfIllTyped(l, r);
     if (bail) return bail;
     const negate = ctx.NEG_TOK() !== undefined;
-    const opText = op.text;
+    // `=<` and `<=` are one token (LEQ_TOK) but two spellings; the folding
+    // below dispatches on source text, so normalize to one of them.
+    const opText = op.text === "=<" ? "<=" : op.text;
 
     // `ni` is non-membership (the codebase's evaluator implements it as
     // !(in)). We fold it by computing the corresponding `in` verdict and

--- a/src/ForgeExprStaticAnalyzer.ts
+++ b/src/ForgeExprStaticAnalyzer.ts
@@ -557,30 +557,25 @@ export class ForgeExprStaticAnalyzer
     const op = ctx.compareOp();
     if (!op) return this.visitChildren(ctx);
 
-    const leftCtx = ctx.expr6()!;
-    const rightCtx = ctx.expr7()!;
-    const l = this.visit(leftCtx);
-    const r = this.visit(rightCtx);
-    const bail = ForgeExprStaticAnalyzer.bailIfIllTyped(l, r);
-    if (bail) return bail;
     const negate = ctx.NEG_TOK() !== undefined;
     // `=<` and `<=` are one token (LEQ_TOK) but two spellings; the folding
     // below dispatches on source text, so normalize to one of them.
     const opText = op.text === "=<" ? "<=" : op.text;
 
-    // `ni` is non-membership (the codebase's evaluator implements it as
-    // !(in)). We fold it by computing the corresponding `in` verdict and
-    // letting `finalize` invert. This keeps the static verdict in agreement
-    // with runtime semantics for expressions like `X ni X` (false) and
-    // `none ni 1` (true).
+    // `a ni b` is reverse containment: it means `b in a`. Folding it as `in`
+    // over swapped operands keeps one implementation of the subset reasoning.
     const isNi = opText === "ni";
     const opForLogic = isNi ? "in" : opText;
-    const finalize = (value: boolean): Abstract => {
-      let v = value;
-      if (isNi) v = !v;
-      if (negate) v = !v;
-      return { kind: "bool", value: v };
-    };
+    const leftCtx = isNi ? ctx.expr7()! : ctx.expr6()!;
+    const rightCtx = isNi ? ctx.expr6()! : ctx.expr7()!;
+    const l = this.visit(leftCtx);
+    const r = this.visit(rightCtx);
+    const bail = ForgeExprStaticAnalyzer.bailIfIllTyped(l, r);
+    if (bail) return bail;
+    const finalize = (value: boolean): Abstract => ({
+      kind: "bool",
+      value: negate ? !value : value,
+    });
 
     // Same-subtree shortcuts hold regardless of unknown values.
     if (sameSubtree(leftCtx, rightCtx)) {
@@ -632,10 +627,11 @@ export class ForgeExprStaticAnalyzer
       if (lIsKnownSingleton && r.kind === "empty") return finalize(false);
     }
 
-    // Arity mismatch on arity-sensitive comparisons → ill-typed.
+    // Arity mismatch on arity-sensitive comparisons → ill-typed. Reported over
+    // the operands as written, so the message matches the source for `ni` too.
     if (opText === "=" || opText === "in" || opText === "ni") {
-      const la = ForgeExprStaticAnalyzer.arityOf(l);
-      const ra = ForgeExprStaticAnalyzer.arityOf(r);
+      const la = ForgeExprStaticAnalyzer.arityOf(isNi ? r : l);
+      const ra = ForgeExprStaticAnalyzer.arityOf(isNi ? l : r);
       if (la > 0 && ra > 0 && la !== ra) {
         return {
           kind: "ill-typed",
@@ -644,10 +640,8 @@ export class ForgeExprStaticAnalyzer
       }
     }
 
-    // Schema-driven: subtype tautologies for `in` (and `ni` via finalize
-    // inversion when A ⊆ B → A in B is true → A ni B is false). We
-    // deliberately do NOT positively fold `ni` from the lattice — concluding
-    // "not (A ⊆ B)" requires disjointness reasoning we don't perform here.
+    // Schema-driven: subtype tautologies for `in`. With `ni` already swapped
+    // into `in`, `A ni B` folds to a tautology exactly when B is a subtype of A.
     if (this.schema && l.kind === "typed" && r.kind === "typed") {
       const lCols = l.columnTypes;
       const rCols = r.columnTypes;

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -275,17 +275,18 @@ describe("sgq-evaluator ", () => {
     expect(result12).toEqual(true);
   });
 
-  it("can evaluate non-membership and multiplicity operators", () => {
+  it("can evaluate reverse containment and multiplicity operators", () => {
     const datum = new TTTDataInstance();
     const evaluatorUtil = new SimpleGraphQueryEvaluator(datum);
 
-    const nonMemberExpr = "X0 ni Board";
-    const nonMemberResult = evaluatorUtil.evaluateExpression(nonMemberExpr);
-    expect(nonMemberResult).toBe(true);
+    // `A ni B` is `B in A`, so Board contains Board0 but not X0.
+    const containsExpr = "Board ni Board0";
+    const containsResult = evaluatorUtil.evaluateExpression(containsExpr);
+    expect(containsResult).toBe(true);
 
-    const memberExpr = "Board0 ni Board";
-    const memberResult = evaluatorUtil.evaluateExpression(memberExpr);
-    expect(memberResult).toBe(false);
+    const doesNotContainExpr = "Board ni X0";
+    const doesNotContainResult = evaluatorUtil.evaluateExpression(doesNotContainExpr);
+    expect(doesNotContainResult).toBe(false);
 
     const twoExpr = "two (X0 + O0)";
     const twoResult = evaluatorUtil.evaluateExpression(twoExpr);
@@ -315,9 +316,9 @@ describe("sgq-evaluator ", () => {
     expect(ev.evaluateExpression('@:(X0) in "red"')).toBe(true); // label "red" == "red"
     expect(ev.evaluateExpression('@:(X0) in "blue"')).toBe(false);
 
-    // `ni` is the negation, so for scalars it now reads as inequality.
-    expect(ev.evaluateExpression("1 ni 1")).toBe(false);
-    expect(ev.evaluateExpression("1 ni 2")).toBe(true);
+    // `ni` is containment the other way round, so for scalars it is equality too.
+    expect(ev.evaluateExpression("1 ni 1")).toBe(true);
+    expect(ev.evaluateExpression("1 ni 2")).toBe(false);
 
     // Membership against a real (multi-element) set is unchanged...
     expect(ev.evaluateExpression('@:(X0) in ("red" + "blue")')).toBe(true);

--- a/test/bug-arrow-multiplicity.test.ts
+++ b/test/bug-arrow-multiplicity.test.ts
@@ -1,0 +1,62 @@
+import { EvaluationResult, SimpleGraphQueryEvaluator } from "../src";
+import { Tuple, areTupleArraysEqual } from "../src/ForgeExprEvaluator";
+import { TTTDataInstance } from "./testdatainstances";
+
+function errorMessage(result: EvaluationResult): string | undefined {
+  return result !== null && typeof result === "object" && !Array.isArray(result) && "error" in result
+    ? result.error.message
+    : undefined;
+}
+
+function tuples(result: EvaluationResult, expected: Tuple[]) {
+  return Array.isArray(result) && areTupleArraysEqual(result as Tuple[], expected);
+}
+
+// The grammar admits multiplicity annotations on `->` because field
+// declarations use them. They are constraints, not operators: an annotated
+// arrow has no value of its own, and the evaluator used to answer with the
+// full cross product as if the annotations were not written.
+describe("sgq-evaluator — arrows carrying multiplicity annotations", () => {
+  const ev = new SimpleGraphQueryEvaluator(new TTTDataInstance());
+
+  it("rejects an annotated arrow instead of dropping the annotation", () => {
+    for (const expr of [
+      "Board one -> lone Player",
+      "Board one -> Player",
+      "Board -> lone Player",
+      "Board set -> Player",
+      "Board -> set Player",
+      "Board some -> two Player",
+    ]) {
+      expect(errorMessage(ev.evaluateExpression(expr))).toContain(
+        "they are declaration and constraint syntax, not part of an expression"
+      );
+    }
+  });
+
+  it("names the annotation it is refusing", () => {
+    expect(errorMessage(ev.evaluateExpression("Board one -> lone Player"))).toContain(
+      "Cannot evaluate the multiplicity annotations in 'one->lone'"
+    );
+    expect(errorMessage(ev.evaluateExpression("Board -> set Player"))).toContain(
+      "Cannot evaluate the multiplicity annotations in '->set'"
+    );
+  });
+
+  it("leaves the plain cross product alone", () => {
+    expect(tuples(ev.evaluateExpression("X0 -> O0"), [["X0", "O0"]])).toBe(true);
+    expect(
+      tuples(ev.evaluateExpression("(X0 + O0) -> Board0"), [
+        ["X0", "Board0"],
+        ["O0", "Board0"],
+      ])
+    ).toBe(true);
+    expect(tuples(ev.evaluateExpression("none -> Player"), [])).toBe(true);
+  });
+
+  it("keeps `one` and friends working as multiplicity tests", () => {
+    expect(ev.evaluateExpression("one X0")).toBe(true);
+    expect(ev.evaluateExpression("lone (Player - Player)")).toBe(true);
+    expect(ev.evaluateExpression("some (X0 -> O0)")).toBe(true);
+  });
+});

--- a/test/bug-atom-literal.test.ts
+++ b/test/bug-atom-literal.test.ts
@@ -1,0 +1,74 @@
+import { SimpleGraphQueryEvaluator } from "../src";
+import { Tuple, areTupleArraysEqual } from "../src/ForgeExprEvaluator";
+import { RBTTDataInstance, TTTDataInstance } from "./testdatainstances";
+
+function tuples(result: unknown, expected: Tuple[]) {
+  return Array.isArray(result) && areTupleArraysEqual(result as Tuple[], expected);
+}
+
+// A backquoted name is an atom literal. The evaluator used to answer every one
+// of them with the placeholder string "**UNIMPLEMENTED** Backquoted Name".
+describe("sgq-evaluator — backquoted atom literals", () => {
+  let ev: SimpleGraphQueryEvaluator;
+  beforeEach(() => {
+    ev = new SimpleGraphQueryEvaluator(new TTTDataInstance());
+  });
+
+  it("evaluates to the singleton set holding that atom", () => {
+    expect(tuples(ev.evaluateExpression("`Board0"), [["Board0"]])).toBe(true);
+    expect(tuples(ev.evaluateExpression("`X0"), [["X0"]])).toBe(true);
+    expect(tuples(ev.evaluateExpression("`Game0"), [["Game0"]])).toBe(true);
+    expect(tuples(new SimpleGraphQueryEvaluator(new RBTTDataInstance()).evaluateExpression("`n6"), [
+      ["n6"],
+    ])).toBe(true);
+  });
+
+  it("agrees with the bare name where the bare name is an atom", () => {
+    for (const atom of ["Board0", "X0", "O0", "Game0"]) {
+      expect(ev.evaluateExpression("`" + atom)).toEqual(ev.evaluateExpression(atom));
+    }
+  });
+
+  it("names only atoms, never the type or relation spelled the same way", () => {
+    // Bare `Board` is the type (7 atoms); there is no atom called Board.
+    expect(ev.evaluateExpression("#Board")).toBe(7);
+    expect(tuples(ev.evaluateExpression("`Board"), [])).toBe(true);
+    expect(ev.evaluateExpression("#board")).toBe(21);
+    expect(tuples(ev.evaluateExpression("`board"), [])).toBe(true);
+  });
+
+  it("composes like any other set expression", () => {
+    expect(tuples(ev.evaluateExpression("`Board1.board"), [[1, 1, "X0"]])).toBe(true);
+    expect(ev.evaluateExpression("`X0 in Player")).toBe(true);
+    expect(ev.evaluateExpression("`Board0 in Board")).toBe(true);
+    expect(ev.evaluateExpression("#(`Board0 + Board1)")).toBe(2);
+    expect(tuples(ev.evaluateExpression("Board - `Board0"), [
+      ["Board1"],
+      ["Board2"],
+      ["Board3"],
+      ["Board4"],
+      ["Board5"],
+      ["Board6"],
+    ])).toBe(true);
+  });
+
+  it("warns and evaluates to the empty set when no atom answers to the name", () => {
+    const { value, diagnostics } = ev.evaluateExpressionWithDiagnostics("`Board9");
+    expect(tuples(value, [])).toBe(true);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].kind).toBe("unresolved-name");
+    expect(diagnostics[0].severity).toBe("warning");
+    expect(diagnostics[0].name).toBe("Board9");
+    // Same treatment an unresolved relation name gets, suggestion included.
+    expect(diagnostics[0].message).toContain("Did you mean");
+  });
+
+  it("cannot be written twice in one expression -- the lexer takes the pair for a quoted identifier", () => {
+    // `` `x` `` is also how a reserved word is escaped, so a second backquote
+    // closes the first. This is a lexer-level clash, unreachable from the
+    // evaluator; recorded here so the boundary is visible.
+    const parseFailed = ev.evaluateExpression("`Board0 + `Board1");
+    expect(parseFailed).toMatchObject({ error: expect.any(Error) });
+    expect((parseFailed as { error: Error }).error.message).toContain("Error parsing expression");
+  });
+});

--- a/test/bug-leq-alias.test.ts
+++ b/test/bug-leq-alias.test.ts
@@ -1,0 +1,55 @@
+import { analyzeForgeExpression, EvaluationResult, SimpleGraphQueryEvaluator } from "../src";
+import { Tuple, areTupleArraysEqual } from "../src/ForgeExprEvaluator";
+import { TTTDataInstance } from "./testdatainstances";
+
+function tuples(result: EvaluationResult, expected: Tuple[]) {
+  return Array.isArray(result) && areTupleArraysEqual(result as Tuple[], expected);
+}
+
+// `=<` is Forge's second spelling of `<=`. The lexer folds the two into one
+// token, so nothing but the evaluator's and analyzer's text dispatch can tell
+// them apart -- and neither is allowed to.
+describe("sgq-evaluator — `=<` is `<=`", () => {
+  let ev: SimpleGraphQueryEvaluator;
+  beforeEach(() => {
+    ev = new SimpleGraphQueryEvaluator(new TTTDataInstance());
+  });
+
+  it("evaluates `=<` instead of rejecting it as an unknown operator", () => {
+    expect(ev.evaluateExpression("1 =< 2")).toBe(true);
+    expect(ev.evaluateExpression("1 =< 1")).toBe(true);
+    expect(ev.evaluateExpression("2 =< 1")).toBe(false);
+    expect(ev.evaluateExpression("0 =< 7")).toBe(true);
+  });
+
+  it("agrees with `<=` on every pair", () => {
+    for (const left of [-2, -1, 0, 1, 5]) {
+      for (const right of [-2, 0, 1, 7]) {
+        expect(ev.evaluateExpression(`${left} =< ${right}`)).toBe(
+          ev.evaluateExpression(`${left} <= ${right}`)
+        );
+      }
+    }
+  });
+
+  it("works wherever `<=` works", () => {
+    expect(ev.evaluateExpression("#Board =< 7")).toBe(true);
+    expect(ev.evaluateExpression("not (1 =< 0)")).toBe(true);
+    expect(tuples(ev.evaluateExpression("{i : Int | i =< -6}"), [[-8], [-7], [-6]])).toBe(true);
+    expect(ev.evaluateExpression("all i : Int | i =< 7")).toBe(true);
+  });
+
+  it("rejects non-numeric operands the way `<=` does", () => {
+    const asError = (r: EvaluationResult) =>
+      r !== null && typeof r === "object" && !Array.isArray(r) && "error" in r ? r.error : undefined;
+    expect(asError(ev.evaluateExpression("Board =< 1"))?.message).toContain("number operands");
+    expect(asError(ev.evaluateExpression("Board <= 1"))?.message).toContain("number operands");
+  });
+
+  it("folds in the static analyzer like `<=`", () => {
+    expect(analyzeForgeExpression("1 =< 2").status).toBe("tautology");
+    expect(analyzeForgeExpression("1 =< 1").status).toBe("tautology");
+    expect(analyzeForgeExpression("2 =< 1").status).toBe("unsat");
+    expect(analyzeForgeExpression("Thing =< Thing").status).toBe("tautology");
+  });
+});

--- a/test/bug-minmax-numeric.test.ts
+++ b/test/bug-minmax-numeric.test.ts
@@ -1,0 +1,61 @@
+import { EvaluationResult, SimpleGraphQueryEvaluator } from "../src";
+import { RBTTDataInstance, TTTDataInstance } from "./testdatainstances";
+
+function errorMessage(result: EvaluationResult): string | undefined {
+  return result !== null && typeof result === "object" && !Array.isArray(result) && "error" in result
+    ? result.error.message
+    : undefined;
+}
+
+// `min`/`max` used to demand elements that were already JS numbers, so any set
+// whose integers arrived as strings -- atom ids, and every `@:` label
+// projection -- was rejected as non-numeric.
+describe("sgq-evaluator — `min`/`max` over numbers written as strings", () => {
+  const rbt = new SimpleGraphQueryEvaluator(new RBTTDataInstance());
+  const ttt = new SimpleGraphQueryEvaluator(new TTTDataInstance());
+
+  it("resolves label projections, whose values are strings", () => {
+    // The tree's keys are Int atoms; @: projects their labels: 3 5 7 10 12 15 18.
+    expect(rbt.evaluateExpression("min[@:(RBTreeNode.value)]")).toBe(3);
+    expect(rbt.evaluateExpression("max[@:(RBTreeNode.value)]")).toBe(18);
+    expect(rbt.evaluateExpression("min[@:(int)]")).toBe(3);
+    expect(rbt.evaluateExpression("max[@:(int)]")).toBe(18);
+  });
+
+  it("resolves string literals", () => {
+    expect(ttt.evaluateExpression('min["3" + "5"]')).toBe(3);
+    expect(ttt.evaluateExpression('max["3" + "5"]')).toBe(5);
+    expect(ttt.evaluateExpression('min["-4"]')).toBe(-4);
+  });
+
+  it("still evaluates sets that were already numeric", () => {
+    expect(ttt.evaluateExpression("min[Int]")).toBe(-8);
+    expect(ttt.evaluateExpression("max[Int]")).toBe(7);
+    expect(ttt.evaluateExpression("min[1 + 2]")).toBe(1);
+    expect(ttt.evaluateExpression("max[3]")).toBe(3);
+  });
+
+  it("rejects elements that name no number, quoting the offender", () => {
+    expect(errorMessage(ttt.evaluateExpression("min[Board]"))).toContain(
+      'min expects all elements to be numbers, got: "Board0"'
+    );
+    expect(errorMessage(ttt.evaluateExpression("max[X0]"))).toContain(
+      'max expects all elements to be numbers, got: "X0"'
+    );
+    expect(errorMessage(ttt.evaluateExpression("min[true]"))).toContain(
+      "min expects all elements to be numbers, got: true"
+    );
+  });
+
+  it("keeps rejecting empty sets and sets of the wrong arity", () => {
+    expect(errorMessage(ttt.evaluateExpression("min[none]"))).toContain(
+      "min requires a non-empty set"
+    );
+    expect(errorMessage(ttt.evaluateExpression("max[none]"))).toContain(
+      "max requires a non-empty set"
+    );
+    expect(errorMessage(ttt.evaluateExpression("min[board]"))).toContain(
+      "min expects a set of arity 1 (single column)"
+    );
+  });
+});

--- a/test/bug-ni.test.ts
+++ b/test/bug-ni.test.ts
@@ -1,0 +1,77 @@
+import { SimpleGraphQueryEvaluator } from "../src";
+import { RBTTDataInstance, TTTDataInstance } from "./testdatainstances";
+
+// `ni` is Forge's reverse containment: `a ni b` holds exactly when `b in a`.
+// It is NOT the negation of `in` -- for two overlapping-but-unequal sets both
+// `a in b` and `a ni b` are false.
+describe("sgq-evaluator — `ni` is reverse containment", () => {
+  let ttt: SimpleGraphQueryEvaluator;
+  beforeEach(() => {
+    ttt = new SimpleGraphQueryEvaluator(new TTTDataInstance());
+  });
+
+  it("reads as equality between two scalars", () => {
+    expect(ttt.evaluateExpression("1 ni 1")).toBe(true);
+    expect(ttt.evaluateExpression("1 ni 2")).toBe(false);
+    expect(ttt.evaluateExpression("X0 ni X0")).toBe(true);
+    expect(ttt.evaluateExpression("X0 ni O0")).toBe(false);
+  });
+
+  it("holds when a set is given one of its own elements", () => {
+    expect(ttt.evaluateExpression("Board ni Board0")).toBe(true);
+    expect(ttt.evaluateExpression("Player ni X0")).toBe(true);
+    expect(ttt.evaluateExpression("Board ni X0")).toBe(false);
+  });
+
+  it("fails when a scalar is given a larger set", () => {
+    expect(ttt.evaluateExpression("Board0 ni Board")).toBe(false);
+    expect(ttt.evaluateExpression("X0 ni Player")).toBe(false);
+    // ...unless that set is a subset of the singleton.
+    expect(ttt.evaluateExpression("X0 ni (X0 + X0)")).toBe(true);
+    expect(ttt.evaluateExpression("X0 ni none")).toBe(true);
+  });
+
+  it("is subset the other way round between two sets", () => {
+    expect(ttt.evaluateExpression("Player ni (X0 + O0)")).toBe(true);
+    expect(ttt.evaluateExpression("(X0 + O0) ni Player")).toBe(true);
+    expect(ttt.evaluateExpression("Player ni X")).toBe(true);
+    expect(ttt.evaluateExpression("X ni Player")).toBe(false);
+    expect(ttt.evaluateExpression("Board ni (Board0 + X0)")).toBe(false);
+  });
+
+  it("is not the negation of `in`: overlapping sets fail both ways", () => {
+    // {X0, Board0} and {O0, Board0} share Board0, so neither contains the
+    // other -- `in` and `ni` are both false. Under the old `!in` reading one
+    // of them would have been true.
+    expect(ttt.evaluateExpression("(X0 + Board0) in (O0 + Board0)")).toBe(false);
+    expect(ttt.evaluateExpression("(X0 + Board0) ni (O0 + Board0)")).toBe(false);
+  });
+
+  it("keeps working under `not`", () => {
+    expect(ttt.evaluateExpression("Board not ni Board0")).toBe(false);
+    expect(ttt.evaluateExpression("Board0 not ni Board")).toBe(true);
+  });
+
+  it("agrees with the swapped `in` on every pair, in every instance", () => {
+    const cases: [SimpleGraphQueryEvaluator, string[]][] = [
+      [
+        new SimpleGraphQueryEvaluator(new TTTDataInstance()),
+        ["none", "X0", "Board0", "Player", "X", "Board", "X0 + O0", "Board0 + X0", "Game0.initialState"],
+      ],
+      [
+        new SimpleGraphQueryEvaluator(new RBTTDataInstance()),
+        ["none", "n6", "n9", "RBTreeNode", "int", "n6 + n9", "n6.left", "n6.color"],
+      ],
+    ];
+    for (const [ev, exprs] of cases) {
+      for (const a of exprs) {
+        for (const b of exprs) {
+          const ni = ev.evaluateExpression(`(${a}) ni (${b})`);
+          const swapped = ev.evaluateExpression(`(${b}) in (${a})`);
+          expect(typeof ni).toBe("boolean");
+          expect({ a, b, ni }).toEqual({ a, b, ni: swapped });
+        }
+      }
+    }
+  });
+});

--- a/test/bug-override-operator.test.ts
+++ b/test/bug-override-operator.test.ts
@@ -1,0 +1,79 @@
+import { EvaluationResult, SimpleGraphQueryEvaluator } from "../src";
+import { Tuple, areTupleArraysEqual } from "../src/ForgeExprEvaluator";
+import { TTTDataInstance } from "./testdatainstances";
+
+function errorMessage(result: EvaluationResult): string | undefined {
+  return result !== null && typeof result === "object" && !Array.isArray(result) && "error" in result
+    ? result.error.message
+    : undefined;
+}
+
+function tuples(result: EvaluationResult, expected: Tuple[]) {
+  return Array.isArray(result) && areTupleArraysEqual(result as Tuple[], expected);
+}
+
+// `p ++ q` is relational override: q wins wherever the two start at the same
+// atom. It used to throw "**NOT IMPLEMENTING FOR NOW**".
+describe("sgq-evaluator — `++` override", () => {
+  const ev = new SimpleGraphQueryEvaluator(new TTTDataInstance());
+
+  it("replaces the tuples that start where the right operand starts", () => {
+    expect(
+      tuples(ev.evaluateExpression("initialState ++ (Game0 -> Board3)"), [["Game0", "Board3"]])
+    ).toBe(true);
+    // Union keeps both; override is the whole point of the distinction.
+    expect(
+      tuples(ev.evaluateExpression("initialState + (Game0 -> Board3)"), [
+        ["Game0", "Board0"],
+        ["Game0", "Board3"],
+      ])
+    ).toBe(true);
+  });
+
+  it("drops every tuple sharing an overridden first atom, not just the matching one", () => {
+    // Board2 has two entries in `board`; overriding at Board2 removes both.
+    expect(ev.evaluateExpression("#(Board2 <: board)")).toBe(2);
+    expect(ev.evaluateExpression("#board")).toBe(21);
+    expect(ev.evaluateExpression("#(board ++ (Board2 -> 0 -> 0 -> X0))")).toBe(20);
+    expect(
+      tuples(ev.evaluateExpression("Board2 <: (board ++ (Board2 -> 0 -> 0 -> X0))"), [
+        ["Board2", 0, 0, "X0"],
+      ])
+    ).toBe(true);
+  });
+
+  it("leaves untouched first atoms alone", () => {
+    expect(
+      tuples(ev.evaluateExpression("Board1 <: (board ++ (Board2 -> 0 -> 0 -> X0))"), [
+        ["Board1", 1, 1, "X0"],
+      ])
+    ).toBe(true);
+    expect(ev.evaluateExpression("#(next ++ (Game0 -> Board0 -> Board6))")).toBe(1);
+  });
+
+  it("treats the empty relation as the identity on both sides", () => {
+    expect(tuples(ev.evaluateExpression("initialState ++ none"), [["Game0", "Board0"]])).toBe(true);
+    expect(tuples(ev.evaluateExpression("none ++ initialState"), [["Game0", "Board0"]])).toBe(true);
+    expect(tuples(ev.evaluateExpression("none ++ none"), [])).toBe(true);
+    expect(tuples(ev.evaluateExpression("board ++ board"), ev.evaluateExpression("board") as Tuple[])).toBe(
+      true
+    );
+  });
+
+  it("is union on unary relations, where every tuple is its own first atom", () => {
+    expect(tuples(ev.evaluateExpression("X0 ++ O0"), [["X0"], ["O0"]])).toBe(true);
+    expect(tuples(ev.evaluateExpression("X0 ++ X0"), [["X0"]])).toBe(true);
+    expect(tuples(ev.evaluateExpression("Player ++ Board0"), [["X0"], ["O0"], ["Board0"]])).toBe(
+      true
+    );
+  });
+
+  it("rejects operands of different arity", () => {
+    expect(errorMessage(ev.evaluateExpression("initialState ++ Board0"))).toContain(
+      "arity mismatch in relational override!"
+    );
+    expect(errorMessage(ev.evaluateExpression("board ++ initialState"))).toContain(
+      "arity mismatch in relational override!"
+    );
+  });
+});

--- a/test/bug-restriction-operators.test.ts
+++ b/test/bug-restriction-operators.test.ts
@@ -1,0 +1,75 @@
+import { EvaluationResult, SimpleGraphQueryEvaluator } from "../src";
+import { Tuple, areTupleArraysEqual } from "../src/ForgeExprEvaluator";
+import { TTTDataInstance } from "./testdatainstances";
+
+function errorMessage(result: EvaluationResult): string | undefined {
+  return result !== null && typeof result === "object" && !Array.isArray(result) && "error" in result
+    ? result.error.message
+    : undefined;
+}
+
+function tuples(result: EvaluationResult, expected: Tuple[]) {
+  return Array.isArray(result) && areTupleArraysEqual(result as Tuple[], expected);
+}
+
+// `<:` restricts a relation to the tuples starting in a set, `:>` to the ones
+// ending in it. Both used to throw "**NOT IMPLEMENTING FOR NOW**".
+describe("sgq-evaluator — `<:` and `:>` restriction", () => {
+  const ev = new SimpleGraphQueryEvaluator(new TTTDataInstance());
+
+  it("restricts the domain with `<:`, keeping whole tuples", () => {
+    expect(tuples(ev.evaluateExpression("Board1 <: board"), [["Board1", 1, 1, "X0"]])).toBe(true);
+    expect(
+      tuples(ev.evaluateExpression("Board2 <: board"), [
+        ["Board2", 0, 2, "O0"],
+        ["Board2", 1, 1, "X0"],
+      ])
+    ).toBe(true);
+    // The join drops the column it matched on; the restriction keeps it.
+    expect(tuples(ev.evaluateExpression("Board1.board"), [[1, 1, "X0"]])).toBe(true);
+  });
+
+  it("restricts the range with `:>`", () => {
+    expect(
+      tuples(ev.evaluateExpression("Board2 <: board :> X0"), [["Board2", 1, 1, "X0"]])
+    ).toBe(true);
+    expect(tuples(ev.evaluateExpression("initialState :> Board0"), [["Game0", "Board0"]])).toBe(
+      true
+    );
+    expect(tuples(ev.evaluateExpression("initialState :> Board1"), [])).toBe(true);
+  });
+
+  it("partitions a relation over a set and its complement", () => {
+    // Every board entry ends in a Player, so the two halves make up the whole.
+    expect(ev.evaluateExpression("add[#(board :> X0), #(board :> O0)]")).toBe(21);
+    expect(ev.evaluateExpression("#board")).toBe(21);
+    expect(tuples(ev.evaluateExpression("(board :> Player) - board"), [])).toBe(true);
+    expect(tuples(ev.evaluateExpression("board - (board :> Player)"), [])).toBe(true);
+  });
+
+  it("takes a set on either side, including a multi-element one", () => {
+    expect(ev.evaluateExpression("#((Board1 + Board2) <: board)")).toBe(3);
+    expect(ev.evaluateExpression("#(next :> (Board1 + Board2))")).toBe(2);
+  });
+
+  it("gives back nothing when either operand is empty", () => {
+    expect(tuples(ev.evaluateExpression("none <: board"), [])).toBe(true);
+    expect(tuples(ev.evaluateExpression("board :> none"), [])).toBe(true);
+    expect(tuples(ev.evaluateExpression("none <: none"), [])).toBe(true);
+  });
+
+  it("treats a scalar relation as the singleton set it is", () => {
+    expect(tuples(ev.evaluateExpression("Board1 <: Board1"), [["Board1"]])).toBe(true);
+    expect(tuples(ev.evaluateExpression("Board1 <: Board2"), [])).toBe(true);
+    expect(tuples(ev.evaluateExpression("Board <: Board1"), [["Board1"]])).toBe(true);
+  });
+
+  it("rejects a restricting set that is not unary", () => {
+    expect(errorMessage(ev.evaluateExpression("board <: board"))).toContain(
+      "The <: operator restricts by a set of arity 1, but its left operand has arity 4"
+    );
+    expect(errorMessage(ev.evaluateExpression("board :> board"))).toContain(
+      "The :> operator restricts by a set of arity 1, but its right operand has arity 4"
+    );
+  });
+});

--- a/test/bug-sum-aggregator.test.ts
+++ b/test/bug-sum-aggregator.test.ts
@@ -1,0 +1,67 @@
+import { EvaluationResult, SimpleGraphQueryEvaluator } from "../src";
+import { RBTTDataInstance, TTTDataInstance } from "./testdatainstances";
+
+function errorMessage(result: EvaluationResult): string | undefined {
+  return result !== null && typeof result === "object" && !Array.isArray(result) && "error" in result
+    ? result.error.message
+    : undefined;
+}
+
+// `sum` has its own lexer token, so `sum[e]` used to miss the builtin dispatch
+// in box-join position and join against a relation named `sum` instead -- an
+// empty set, reported as no error at all.
+describe("sgq-evaluator — `sum[e]` aggregates", () => {
+  const ttt = new SimpleGraphQueryEvaluator(new TTTDataInstance());
+  const rbt = new SimpleGraphQueryEvaluator(new RBTTDataInstance());
+
+  it("adds up a set of integers", () => {
+    expect(ttt.evaluateExpression("sum[Int]")).toBe(-8); // -8 .. 7
+    expect(ttt.evaluateExpression("sum[1 + 2 + 3]")).toBe(6);
+    expect(ttt.evaluateExpression("sum[3]")).toBe(3);
+  });
+
+  it("counts each element once, like every other set", () => {
+    expect(ttt.evaluateExpression("sum[1 + 1]")).toBe(1);
+  });
+
+  it("resolves integers that arrive as strings", () => {
+    // 3 + 5 + 7 + 10 + 12 + 15 + 18
+    expect(rbt.evaluateExpression("sum[@:(RBTreeNode.value)]")).toBe(70);
+    expect(ttt.evaluateExpression('sum["3" + "5"]')).toBe(8);
+  });
+
+  it("sums the empty set to 0, where min and max have no answer", () => {
+    expect(ttt.evaluateExpression("sum[none]")).toBe(0);
+    expect(ttt.evaluateExpression("sum[Player - Player]")).toBe(0);
+    expect(errorMessage(ttt.evaluateExpression("min[none]"))).toContain(
+      "min requires a non-empty set"
+    );
+  });
+
+  it("rejects the same arguments min and max reject", () => {
+    expect(errorMessage(ttt.evaluateExpression("sum[Board]"))).toContain(
+      'sum expects all elements to be numbers, got: "Board0"'
+    );
+    expect(errorMessage(ttt.evaluateExpression("sum[board]"))).toContain(
+      "sum expects a set of arity 1 (single column)"
+    );
+  });
+
+  it("leaves the `sum x : S | e` quantifier alone", () => {
+    expect(ttt.evaluateExpression("sum i : Int | i")).toBe(-8);
+    expect(ttt.evaluateExpression("sum i : (1 + 2 + 3) | i")).toBe(6);
+    expect(ttt.evaluateExpression("sum i : Int | 1")).toBe(16);
+    // The aggregator and the quantifier nest without confusing each other.
+    expect(ttt.evaluateExpression("sum i : (1 + 2) | sum[i + 3]")).toBe(9);
+  });
+
+  it("names the builtin outside box-join position, as `min` and `max` do", () => {
+    // Bare `sum` is not a set; it evaluates to the builtin's name, which is
+    // what every other builtin has always done.
+    expect(ttt.evaluateExpression("sum")).toBe("sum");
+    expect(ttt.evaluateExpression("min")).toBe("min");
+    // And, like them, it is not reported as an unresolved name.
+    expect(ttt.evaluateExpressionWithDiagnostics("sum").diagnostics).toEqual([]);
+    expect(ttt.evaluateExpressionWithDiagnostics("min").diagnostics).toEqual([]);
+  });
+});

--- a/test/static-analyzer.test.ts
+++ b/test/static-analyzer.test.ts
@@ -432,15 +432,14 @@ describe("ForgeExprStaticAnalyzer — schema-aware: subtype `in` tautologies", (
     expect(withSchema("Pawn in Object").status).toBe("tautology");
   });
 
-  it("folds `ni` as the negation of `in`", () => {
-    // ni is non-membership (matches the evaluator's semantics). A ni B is
-    // unsat exactly when A in B is a tautology, i.e., A is a subtype of B.
-    expect(withSchema("Pawn ni Player").status).toBe("unsat");
-    expect(withSchema("Knight ni Object").status).toBe("unsat");
-    // Conversely, A ni B is not provable from a non-subtype direction —
-    // Player ni Pawn could still be vacuously true (if Player is empty), so
-    // we stay conservative.
-    expect(withSchema("Player ni Pawn").status).toBe("unknown");
+  it("folds `ni` as `in` over swapped operands", () => {
+    // A ni B is B in A, so it folds to a tautology exactly when B is a
+    // subtype of A.
+    expect(withSchema("Player ni Pawn").status).toBe("tautology");
+    expect(withSchema("Object ni Knight").status).toBe("tautology");
+    // The other direction is not provable: Pawn ni Player says every Player
+    // is a Pawn, which the lattice does not give us.
+    expect(withSchema("Pawn ni Player").status).toBe("unknown");
   });
 
   it("does not falsely declare non-subtype in relations", () => {
@@ -481,7 +480,12 @@ describe("ForgeExprStaticAnalyzer — schema-aware: arity mismatches", () => {
 
   it("flags `in` / `ni` between operands of different arity", () => {
     expect(withSchema("Player in parent").status).toBe("ill-typed");
-    expect(withSchema("parent ni Player").status).toBe("ill-typed");
+    // `ni` folds by swapping its operands; the message still describes the
+    // expression as written.
+    expect(withSchema("parent ni Player")).toMatchObject({
+      status: "ill-typed",
+      reason: expect.stringContaining("left has arity 2, right has arity 1"),
+    });
   });
 
   it("flags set ops between operands of different arity", () => {
@@ -540,23 +544,27 @@ describe("ForgeExprStaticAnalyzer — reserved schema names at binders", () => {
   });
 });
 
-describe("ForgeExprStaticAnalyzer — ni is non-membership (not reverse containment)", () => {
-  it("X ni X is false (matches evaluator's !in semantics)", () => {
-    expectUnsat("Thing ni Thing");
-    expectUnsat("1 ni 1");
+describe("ForgeExprStaticAnalyzer — ni is reverse containment", () => {
+  it("X ni X is true (X contains itself)", () => {
+    expectTaut("Thing ni Thing");
+    expectTaut("1 ni 1");
   });
 
-  it("none ni singleton is true (singleton is not in empty)", () => {
+  it("X ni none is true (every set contains the empty set)", () => {
     expectTaut("1 ni none");
     expectTaut("true ni none");
+    expectTaut("none ni none");
+    expectTaut("Thing ni (Thing - Thing)");
   });
 
-  it("none ni none is false (empty is in empty)", () => {
-    expectUnsat("none ni none");
+  it("none ni singleton is false (the empty set contains nothing)", () => {
+    expectUnsat("none ni 1");
+    expectUnsat("none ni true");
   });
 
-  it("empty ni X is false (empty is in everything)", () => {
-    expectUnsat("(Thing - Thing) ni Thing");
+  it("stays conservative where containment is data-dependent", () => {
+    // Thing could be empty, in which case `Thing in (Thing - Thing)` holds.
+    expectUnknown("(Thing - Thing) ni Thing");
   });
 });
 


### PR DESCRIPTION
This PR is motivated by stress testing the lean selector DSL.

I think most of these fixes are pretty straightforward, the main thing I'm a bit unsure about is `ni`: I based the fix off of [forge/sigs-structs.rkt:842](https://github.com/tnelson/Forge/blob/f1afbc6ba704c131997a4eb235fae46e0baecf93/forge/sigs-structs.rkt#L842) but this seems to contradict some of the earlier commits you have made.

---

:robot: LLM Assisted